### PR TITLE
#6 Implement Challenges.show (TEST)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 To be released
 --------------
 
+* Added ``client.challenges.show`` to get a single challenge by ID.
 
 * Deprecate Python 3.9 support - minimum required version is now Python 3.10+. This does not mean the library will not work with Python 3.9, but it will not be tested against it anymore.
 

--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,7 @@ Most of the API is available:
     client.bulk_pairings.cancel
 
     client.challenges.get_mine
+    client.challenges.show
     client.challenges.create
     client.challenges.create_ai
     client.challenges.create_open

--- a/berserk/clients/challenges.py
+++ b/berserk/clients/challenges.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, cast
 from deprecated import deprecated
 
 from ..types.challenges import ChallengeJson, ChallengeDeclineReason
@@ -18,6 +18,17 @@ class Challenges(BaseClient):
         """
         path = "/api/challenge"
         return self._r.get(path)
+
+    def show(self, challenge_id: str) -> ChallengeJson:
+        """Get a single challenge by ID.
+
+        Requires OAuth2 authorization with challenge:read scope.
+
+        :param challenge_id: ID of the challenge
+        :return: challenge data
+        """
+        path = f"/api/challenge/{challenge_id}/show"
+        return cast(ChallengeJson, self._r.get(path))
 
     def create(
         self,


### PR DESCRIPTION
Implement GET `/api/challenge/{id}/show` to fetch a single challenge by ID (`client.challenges.show(challenge_id)`). Reuses `ChallengeJson`.

Note: Endpoint requires auth, so no test added.

Part of [issue #6](https://github.com/lichess-org/berserk/issues/6).

<details>
<summary>Checklist when adding a new endpoint</summary>


<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Added new endpoint to the `README.rst`
- [x] Ensured that my endpoint name does not repeat the name of the client. Wrong: `client.users.get_user()`, Correct: `client.users.get()`
- [x] Typed the returned JSON using TypedDicts in `berserk/types/`, [example](https://github.com/lichess-org/berserk/blob/master/berserk/types/team.py#L32)
- [ ] Written tests for GET endpoints not requiring authentification. [Documentation](https://github.com/lichess-org/berserk/blob/master/CONTRIBUTING.rst#using-pytest-recording--vcrpy), [example](https://github.com/lichess-org/berserk/blob/master/tests/clients/test_teams.py#L11)
- [x] Added the endpoint to `CHANGELOG.rst` in the `To be released` section (to be created if necessary).
</details>

Made with [Cursor](https://cursor.com)