### PR TITLE
#6 Add BulkPairings.export_games

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 To be released
 --------------
 
+* Added ``client.bulk_pairings.export_games`` to export games of a bulk pairing (PGN or NDJSON).
 
 * Deprecate Python 3.9 support - minimum required version is now Python 3.10+. This does not mean the library will not work with Python 3.9, but it will not be tested against it anymore.
 

--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,7 @@ Most of the API is available:
 
     client.bulk_pairings.get_upcoming
     client.bulk_pairings.create
+    client.bulk_pairings.export_games
     client.bulk_pairings.start_clocks
     client.bulk_pairings.cancel
 

--- a/berserk/clients/bulk_pairings.py
+++ b/berserk/clients/bulk_pairings.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import cast
+from typing import Any, Dict, Iterator, cast
 
-from ..formats import JSON, JSON_LIST
+from .. import models
+from ..formats import JSON, JSON_LIST, NDJSON, PGN
 from ..types.bulk_pairings import BulkPairing
 from ..types.common import VariantKey
 from .base import BaseClient
@@ -99,3 +100,59 @@ class BulkPairings(BaseClient):
         """
         path = f"/api/bulk-pairing/{bulk_pairing_id}"
         self._r.request("DELETE", path)
+
+    def export_games(
+        self,
+        bulk_pairing_id: str,
+        *,
+        as_pgn: bool = True,
+        moves: bool = True,
+        pgn_in_json: bool = False,
+        tags: bool = True,
+        clocks: bool = False,
+        evals: bool = False,
+        accuracy: bool = False,
+        opening: bool = False,
+        division: bool = False,
+        literate: bool = False,
+    ) -> Iterator[str] | Iterator[Dict[str, Any]]:
+        """Export games of a bulk pairing in PGN or NDJSON format.
+
+        Response format is controlled by ``as_pgn``: PGN returns one game per
+        yielded string; NDJSON yields one JSON object per game.
+
+        :param bulk_pairing_id: id of the bulk pairing
+        :param as_pgn: whether to return PGN (default True) or NDJSON
+        :param moves: include the PGN moves
+        :param pgn_in_json: include the full PGN in a ``pgn`` field (NDJSON only)
+        :param tags: include the PGN tags
+        :param clocks: include clock comments in PGN or ``clocks`` JSON field
+        :param evals: include analysis evaluations in PGN or ``analysis`` JSON field
+        :param accuracy: include accuracy percent per player (NDJSON only)
+        :param opening: include the opening name
+        :param division: include plies for middlegame/endgame (NDJSON only)
+        :param literate: include textual annotations in PGN
+        :return: iterator over games as PGN strings or JSON dicts
+        """
+        path = f"/api/bulk-pairing/{bulk_pairing_id}/games"
+        params = {
+            "moves": moves,
+            "pgnInJson": pgn_in_json,
+            "tags": tags,
+            "clocks": clocks,
+            "evals": evals,
+            "accuracy": accuracy,
+            "opening": opening,
+            "division": division,
+            "literate": literate,
+        }
+        if as_pgn:
+            yield from self._r.get(path, params=params, fmt=PGN, stream=True)
+        else:
+            yield from self._r.get(
+                path,
+                params=params,
+                fmt=NDJSON,
+                stream=True,
+                converter=models.Game.convert,
+            )

--- a/tests/clients/test_bulk_pairings.py
+++ b/tests/clients/test_bulk_pairings.py
@@ -7,20 +7,50 @@ def test_export_games_hits_correct_path_and_params():
     """Verify export_games requests GET /api/bulk-pairing/{id}/games with params."""
     with requests_mock.Mocker() as m:
         m.get(
-            "https://lichess.org/api/bulk-pairing/5IrD6Gzz/games",
+            "https://lichess.org/api/bulk-pairing/5IrD6Gzz/games?moves=True&pgnInJson=False&tags=True&clocks=True&evals=False&accuracy=False&opening=True&division=False&literate=False",
             text='[Event "?"]\n\n1. e4 e5 1-0\n\n',
+        )
+        client = Client()
+        list(
+            client.bulk_pairings.export_games(
+                "5IrD6Gzz",
+                as_pgn=True,
+                moves=True,
+                pgn_in_json=False,
+                tags=True,
+                clocks=True,
+                evals=False,
+                accuracy=False,
+                opening=True,
+                division=False,
+                literate=False,
+            )
+        )
+
+
+def test_export_games_as_ndjson_returns_dicts():
+    """Verify export_games with as_pgn=False requests NDJSON and yields game dicts."""
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://lichess.org/api/bulk-pairing/5IrD6Gzz/games?moves=False&pgnInJson=False&tags=False&clocks=False&evals=False&accuracy=False&opening=False&division=False&literate=False",
+            text='{"id":"abc123","rated":false}\n',
         )
         client = Client()
         result = list(
             client.bulk_pairings.export_games(
                 "5IrD6Gzz",
-                as_pgn=True,
+                as_pgn=False,
                 moves=False,
+                pgn_in_json=False,
                 tags=False,
+                clocks=False,
+                evals=False,
+                accuracy=False,
+                opening=False,
+                division=False,
+                literate=False,
             )
         )
-        assert len(result) >= 1
-        request = m.request_history[0]
-        assert request.path_url.startswith("/api/bulk-pairing/5IrD6Gzz/games")
-        assert request.qs["moves"] == ["false"]
-        assert request.qs["tags"] == ["false"]
+        assert len(result) == 1
+        assert result[0]["id"] == "abc123"
+        assert result[0]["rated"] is False

--- a/tests/clients/test_bulk_pairings.py
+++ b/tests/clients/test_bulk_pairings.py
@@ -1,0 +1,26 @@
+import requests_mock
+
+from berserk import Client
+
+
+def test_export_games_hits_correct_path_and_params():
+    """Verify export_games requests GET /api/bulk-pairing/{id}/games with params."""
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://lichess.org/api/bulk-pairing/5IrD6Gzz/games",
+            text='[Event "?"]\n\n1. e4 e5 1-0\n\n',
+        )
+        client = Client()
+        result = list(
+            client.bulk_pairings.export_games(
+                "5IrD6Gzz",
+                as_pgn=True,
+                moves=False,
+                tags=False,
+            )
+        )
+        assert len(result) >= 1
+        request = m.request_history[0]
+        assert request.path_url.startswith("/api/bulk-pairing/5IrD6Gzz/games")
+        assert request.qs["moves"] == ["false"]
+        assert request.qs["tags"] == ["false"]


### PR DESCRIPTION
Part of #6.

Add `client.bulk_pairings.export_games` for GET `/api/bulk-pairing/{id}/games`: export games of a bulk pairing as PGN or NDJSON stream. Supports moves, tags, clocks, evals, accuracy, opening, division, literate, pgnInJson. Uses existing Game model for NDJSON; requests-mock test (endpoint requires auth).

<details>
<summary>Checklist when adding a new endpoint</summary>

- [x] Added new endpoint to the README.rst
- [x] Ensured that my endpoint name does not repeat the name of the client (export_games, not bulk_pairing_export_games)
- [x] Typed the returned JSON using TypedDicts in berserk/types/ (NDJSON response uses existing Game model; no new types)
- [x] Written tests for GET endpoints not requiring authentification (endpoint requires auth; added requests-mock test for path and params)
- [x] Added the endpoint to CHANGELOG.rst in the To be released section
</details>
