### PR TITLE
#6 Add Broadcasts.get_player

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 To be released
 --------------
 
+* Added ``client.broadcasts.get_player`` to get a single player of a broadcast tournament.
 
 * Deprecate Python 3.9 support - minimum required version is now Python 3.10+. This does not mean the library will not work with Python 3.9, but it will not be tested against it anymore.
 

--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,7 @@ Most of the API is available:
     client.broadcasts.get_top
     client.broadcasts.search
     client.broadcasts.get_by_user
+    client.broadcasts.get_player
 
     client.bulk_pairings.get_upcoming
     client.bulk_pairings.create

--- a/berserk/clients/broadcasts.py
+++ b/berserk/clients/broadcasts.py
@@ -9,6 +9,7 @@ from .base import BaseClient
 from ..types.broadcast import (
     BroadcastPlayer,
     BroadcastTop,
+    BroadcastTournamentPlayer,
     PaginatedBroadcasts,
     BroadcastsByUser,
 )
@@ -296,3 +297,15 @@ class Broadcasts(BaseClient):
         path = f"/api/broadcast/by/{username}"
         params = {"page": page, "html": html}
         return cast(BroadcastsByUser, self._r.get(path, params=params))
+
+    def get_player(
+        self, broadcast_tournament_id: str, player_id: str
+    ) -> BroadcastTournamentPlayer:
+        """Get a single player of a broadcast tournament.
+
+        :param broadcast_tournament_id: ID of the broadcast tournament (8 characters)
+        :param player_id: ID of the player (e.g. FIDE ID)
+        :return: the broadcast tournament player
+        """
+        path = f"/broadcast/{broadcast_tournament_id}/players/{player_id}"
+        return cast(BroadcastTournamentPlayer, self._r.get(path))

--- a/berserk/types/__init__.py
+++ b/berserk/types/__init__.py
@@ -12,6 +12,7 @@ from .account import (
 from .broadcast import (
     BroadcastPlayer,
     BroadcastTop,
+    BroadcastTournamentPlayer,
     PaginatedBroadcasts,
     BroadcastsByUser,
 )
@@ -37,6 +38,7 @@ __all__ = [
     "ArenaResult",
     "BroadcastPlayer",
     "BroadcastsByUser",
+    "BroadcastTournamentPlayer",
     "BroadcastTop",
     "BulkPairing",
     "BulkPairingGame",

--- a/berserk/types/broadcast.py
+++ b/berserk/types/broadcast.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List
+from typing import Dict, List
 
 from typing_extensions import NotRequired, TypedDict
 
@@ -104,3 +104,54 @@ class BroadcastsByUser(TypedDict):
     previousPage: int | None
     nextPage: int | None
     nbPages: int
+
+
+class BroadcastTournamentPlayerOpponent(TypedDict):
+    name: str
+    title: NotRequired[str]
+    rating: NotRequired[int]
+    fideId: NotRequired[int]
+    team: NotRequired[str]
+    fed: NotRequired[str]
+
+
+class BroadcastTournamentPlayerGame(TypedDict):
+    round: str
+    id: str
+    opponent: BroadcastTournamentPlayerOpponent
+    color: str
+    fideTC: NotRequired[str]
+    points: str
+    ratingDiff: NotRequired[int]
+
+
+class BroadcastTournamentPlayerFideRatings(TypedDict):
+    standard: NotRequired[int]
+    rapid: NotRequired[int]
+    blitz: NotRequired[int]
+
+
+class BroadcastTournamentPlayerFide(TypedDict):
+    year: NotRequired[int]
+    ratings: NotRequired[BroadcastTournamentPlayerFideRatings]
+    follow: NotRequired[bool]
+
+
+class BroadcastTournamentPlayer(TypedDict):
+    """A single player in a broadcast tournament (GET /broadcast/{id}/players/{playerId})."""
+
+    name: str
+    title: NotRequired[str]
+    rating: NotRequired[int]
+    fideId: NotRequired[int]
+    team: NotRequired[str]
+    fed: NotRequired[str]
+    played: NotRequired[int]
+    score: NotRequired[float]
+    ratingDiff: NotRequired[int]
+    ratingsMap: NotRequired[Dict[str, int]]
+    ratingDiffs: NotRequired[Dict[str, int]]
+    performance: NotRequired[int]
+    performances: NotRequired[Dict[str, int]]
+    fide: NotRequired[BroadcastTournamentPlayerFide]
+    games: NotRequired[List[BroadcastTournamentPlayerGame]]

--- a/tests/clients/cassettes/test_broadcasts/TestBroadcasts.test_get_player.yaml
+++ b/tests/clients/cassettes/test_broadcasts/TestBroadcasts.test_get_player.yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.5
+    method: GET
+    uri: https://lichess.org/broadcast/8jXzp45R/players/13401319
+  response:
+    body:
+      string: '{"name":"Mamedyarov, Shakhriyar","title":"GM","rating":2742,"fideId":13401319,"team":"BayeganPendik
+        chess sports","fed":"AZE","played":7,"score":5.5,"ratingDiff":0,"ratingsMap":{"standard":2742},"ratingDiffs":{"standard":0},"performance":2720,"performances":{"standard":2720},"fide":{"year":1985,"ratings":{"standard":2727,"rapid":2712,"blitz":2632},"follow":false},"games":[{"round":"DuJvNdMY","id":"qsEiUcgK","opponent":{"name":"Gijswijt,
+        Bart","title":"FM","rating":2295,"fideId":1009435,"team":"HWP Haarlem","fed":"NED"},"color":"black","fideTC":"standard","points":"1","ratingDiff":1},{"round":"8FA2y61K","id":"qAUwVXO6","opponent":{"name":"Pasti,
+        Aron","title":"IM","rating":2366,"fideId":785857,"team":"SK Dunajska Streda","fed":"HUN"},"color":"white","fideTC":"standard","points":"1","ratingDiff":1},{"round":"00hRO87y","id":"3CspVFvm","opponent":{"name":"Wachinger,
+        Nikolas","title":"IM","rating":2456,"fideId":12962791,"team":"SV Werder Bremen","fed":"GER"},"color":"white","fideTC":"standard","points":"1","ratingDiff":2},{"round":"IBcpk6tK","id":"K0FWdrqT","opponent":{"name":"Eljanov,
+        Pavel","title":"GM","rating":2657,"fideId":14102951,"team":"Tuxera Aquaprofit
+        Nagykanizsai Sakk Klub","fed":"UKR"},"color":"black","fideTC":"standard","points":"0","ratingDiff":-6},{"round":"f7DytHc1","id":"Im8CRTae","opponent":{"name":"Van
+        Foreest, Jorden","title":"GM","rating":2697,"fideId":1039784,"team":"SuperChess","fed":"NED"},"color":"white","fideTC":"standard","points":"1/2","ratingDiff":-1},{"round":"GLJOviZK","id":"ny3SqBVX","opponent":{"name":"Hracek,
+        Zbynek","title":"GM","rating":2539,"fideId":300071,"team":"Sigil Fund Pardubice","fed":"CZE"},"color":"white","fideTC":"standard","points":"1","ratingDiff":2},{"round":"4KlYyGdK","id":"3aRwR78o","opponent":{"name":"Galopoulos,
+        Nikolaos","rating":2425,"fideId":4208951,"team":"Kavala","fed":"GRE"},"color":"black","fideTC":"standard","points":"1","ratingDiff":1}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 24 Feb 2026 22:27:16 GMT
+      Permissions-Policy:
+      - screen-wake-lock=(self "https://lichess1.org"), microphone=(self), fullscreen=(self)
+      - interest-cohort=()
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '1928'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/clients/test_broadcasts.py
+++ b/tests/clients/test_broadcasts.py
@@ -1,7 +1,12 @@
 import pytest
 
 from berserk import Client
-from berserk.types import BroadcastTop, PaginatedBroadcasts, BroadcastsByUser
+from berserk.types import (
+    BroadcastTop,
+    BroadcastTournamentPlayer,
+    PaginatedBroadcasts,
+    BroadcastsByUser,
+)
 from utils import skip_if_older_3_dot_10, validate
 
 
@@ -23,3 +28,11 @@ class TestBroadcasts:
     def test_get_by_user(self):
         res = Client().broadcasts.get_by_user(username="lichess", page=1)
         validate(BroadcastsByUser, res)
+
+    @skip_if_older_3_dot_10
+    @pytest.mark.vcr
+    def test_get_player(self):
+        res = Client().broadcasts.get_player(
+            broadcast_tournament_id="8jXzp45R", player_id="13401319"
+        )
+        validate(BroadcastTournamentPlayer, res)


### PR DESCRIPTION
Part of #6.

Adds `client.broadcasts.get_player(broadcast_tournament_id, player_id)` for GET `/broadcast/{broadcastTournamentId}/players/{playerId}`. Introduces `BroadcastTournamentPlayer` and nested TypedDicts matching the API response, VCR test with a real recorded cassette, and updates to README.rst and CHANGELOG.rst.

**Checklist when adding a new endpoint**

- [x] Added new endpoint to the `README.rst`
- [x] Ensured that my endpoint name does not repeat the name of the client. Wrong: `client.users.get_user()`, Correct: `client.users.get()`
- [x] Typed the returned JSON using TypedDicts in `berserk/types/`, [example](https://github.com/lichess-org/berserk/blob/master/berserk/types/team.py#L32)
- [x] Written tests for GET endpoints not requiring authentification. [Documentation](https://github.com/lichess-org/berserk/blob/master/CONTRIBUTING.rst#using-pytest-recording--vcrpy), [example](https://github.com/lichess-org/berserk/blob/master/tests/clients/test_teams.py#L11)
- [x] Added the endpoint and your name to `CHANGELOG.rst` in the `To be released` section (to be created if necessary)
