### PR TITLE
#6 Add Broadcasts.get_team_standings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 To be released
 --------------
 
+* Added ``client.broadcasts.get_team_standings`` to get the team leaderboard of a broadcast.
 
 * Deprecate Python 3.9 support - minimum required version is now Python 3.10+. This does not mean the library will not work with Python 3.9, but it will not be tested against it anymore.
 
@@ -23,6 +24,7 @@ To be released
 
 
 Thanks to all the contributors who helped to this release:
+- Nick Stillman
 - @hsheth2
 - @DoraFgr
 - @MrElyazid

--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,7 @@ Most of the API is available:
     client.broadcasts.get_top
     client.broadcasts.search
     client.broadcasts.get_by_user
+    client.broadcasts.get_team_standings
 
     client.bulk_pairings.get_upcoming
     client.bulk_pairings.create

--- a/berserk/clients/broadcasts.py
+++ b/berserk/clients/broadcasts.py
@@ -8,6 +8,7 @@ from .base import BaseClient
 
 from ..types.broadcast import (
     BroadcastPlayer,
+    BroadcastTeamStandingsItem,
     BroadcastTop,
     PaginatedBroadcasts,
     BroadcastsByUser,
@@ -296,3 +297,14 @@ class Broadcasts(BaseClient):
         path = f"/api/broadcast/by/{username}"
         params = {"page": page, "html": html}
         return cast(BroadcastsByUser, self._r.get(path, params=params))
+
+    def get_team_standings(
+        self, broadcast_tournament_id: str
+    ) -> List[BroadcastTeamStandingsItem]:
+        """Get the team leaderboard of a broadcast.
+
+        :param broadcast_tournament_id: ID of the broadcast tournament
+        :return: list of teams with name, match/board points, matches, and players
+        """
+        path = f"/broadcast/{broadcast_tournament_id}/teams/standings"
+        return cast(List[BroadcastTeamStandingsItem], self._r.get(path))

--- a/berserk/types/__init__.py
+++ b/berserk/types/__init__.py
@@ -11,6 +11,7 @@ from .account import (
 )
 from .broadcast import (
     BroadcastPlayer,
+    BroadcastTeamStandingsItem,
     BroadcastTop,
     PaginatedBroadcasts,
     BroadcastsByUser,
@@ -37,6 +38,7 @@ __all__ = [
     "ArenaResult",
     "BroadcastPlayer",
     "BroadcastsByUser",
+    "BroadcastTeamStandingsItem",
     "BroadcastTop",
     "BulkPairing",
     "BulkPairingGame",

--- a/berserk/types/broadcast.py
+++ b/berserk/types/broadcast.py
@@ -104,3 +104,34 @@ class BroadcastsByUser(TypedDict):
     previousPage: int | None
     nextPage: int | None
     nbPages: int
+
+
+# Types for GET /broadcast/{id}/teams/standings (team leaderboard of a broadcast)
+
+
+class BroadcastTeamStandingsMatch(TypedDict):
+    roundId: str
+    opponent: str
+    points: str
+    mp: int | float
+    gp: int | float
+
+
+class BroadcastTeamStandingsPlayer(TypedDict):
+    name: str
+    score: int | float
+    title: NotRequired[Title]
+    rating: NotRequired[int]
+    fideId: NotRequired[int]
+    team: NotRequired[str]
+    fed: NotRequired[str]
+    played: NotRequired[int]
+
+
+class BroadcastTeamStandingsItem(TypedDict):
+    name: str
+    mp: int | float
+    gp: int | float
+    matches: List[BroadcastTeamStandingsMatch]
+    players: List[BroadcastTeamStandingsPlayer]
+    averageRating: NotRequired[int]

--- a/tests/clients/cassettes/test_broadcasts/TestBroadcasts.test_get_team_standings.yaml
+++ b/tests/clients/cassettes/test_broadcasts/TestBroadcasts.test_get_team_standings.yaml
@@ -1,0 +1,575 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.5
+    method: GET
+    uri: https://lichess.org/broadcast/Y9YjcDKG/teams/standings
+  response:
+    body:
+      string: "[{\"name\":\"SC Viernheim\",\"mp\":8,\"gp\":46,\"matches\":[{\"roundId\":\"SY7G4X9F\",\"opponent\":\"SF
+        Berlin\",\"points\":\"1\",\"mp\":1,\"gp\":5.5},{\"roundId\":\"20EKKqrN\",\"opponent\":\"USV
+        TU Dresden\",\"points\":\"1\",\"mp\":1,\"gp\":6},{\"roundId\":\"IZZCW7IG\",\"opponent\":\"MSA
+        Zugzwang\",\"points\":\"1\",\"mp\":1,\"gp\":6.5},{\"roundId\":\"Woyg2kpP\",\"opponent\":\"Schachfreunde
+        Deizisau\",\"points\":\"1\",\"mp\":1,\"gp\":6},{\"roundId\":\"AlyVP7Tj\",\"opponent\":\"FC
+        St. Pauli\",\"points\":\"1\",\"mp\":1,\"gp\":5},{\"roundId\":\"SR1eddMe\",\"opponent\":\"Hamburger
+        SK\",\"points\":\"1\",\"mp\":1,\"gp\":6},{\"roundId\":\"nRVdmVdP\",\"opponent\":\"SG
+        Solingen\",\"points\":\"1\",\"mp\":1,\"gp\":4.5},{\"roundId\":\"2hgbLbso\",\"opponent\":\"D\xFCsseldorfer
+        SK\",\"points\":\"1\",\"mp\":1,\"gp\":6.5}],\"players\":[{\"name\":\"Wagner,
+        Dennis\",\"title\":\"GM\",\"rating\":2608,\"fideId\":24650684,\"team\":\"SC
+        Viernheim\",\"fed\":\"GER\",\"played\":7,\"score\":5.5},{\"name\":\"Korobov,
+        Anton\",\"title\":\"GM\",\"rating\":2616,\"fideId\":14105730,\"team\":\"SC
+        Viernheim\",\"fed\":\"UKR\",\"played\":4,\"score\":2.5},{\"name\":\"Erdogmus,
+        Yagiz Kaan\",\"title\":\"GM\",\"rating\":2646,\"fideId\":44599790,\"team\":\"SC
+        Viernheim\",\"fed\":\"TUR\",\"played\":2,\"score\":0.5},{\"name\":\"Maghsoodloo,
+        Parham\",\"title\":\"GM\",\"rating\":2708,\"fideId\":12539929,\"team\":\"SC
+        Viernheim\",\"fed\":\"IRI\",\"played\":2,\"score\":1.5},{\"name\":\"Duda,
+        Jan-Krzysztof\",\"title\":\"GM\",\"rating\":2729,\"fideId\":1170546,\"team\":\"SC
+        Viernheim\",\"fed\":\"POL\",\"played\":4,\"score\":3.5},{\"name\":\"Wagner,
+        Dinara\",\"title\":\"IM\",\"rating\":2404,\"fideId\":24157570,\"team\":\"SC
+        Viernheim\",\"fed\":\"GER\",\"played\":3,\"score\":2},{\"name\":\"Mamedyarov,
+        Shakhriyar\",\"title\":\"GM\",\"rating\":2730,\"fideId\":13401319,\"team\":\"SC
+        Viernheim\",\"fed\":\"AZE\",\"played\":4,\"score\":2},{\"name\":\"Sydykov,
+        Bayastan\",\"title\":\"FM\",\"rating\":2388,\"fideId\":13829610,\"team\":\"SC
+        Viernheim\",\"fed\":\"KGZ\",\"played\":2,\"score\":1.5},{\"name\":\"Sarana,
+        Alexey\",\"title\":\"GM\",\"rating\":2686,\"fideId\":24133795,\"team\":\"SC
+        Viernheim\",\"fed\":\"SRB\",\"played\":8,\"score\":6},{\"name\":\"Anton Guijarro,
+        David\",\"title\":\"GM\",\"rating\":2646,\"fideId\":2285525,\"team\":\"SC
+        Viernheim\",\"fed\":\"ESP\",\"played\":4,\"score\":3},{\"name\":\"Buhmann,
+        Rainer\",\"title\":\"GM\",\"rating\":2548,\"fideId\":4651340,\"team\":\"SC
+        Viernheim\",\"fed\":\"GER\",\"played\":2,\"score\":1},{\"name\":\"Van Foreest,
+        Jorden\",\"title\":\"GM\",\"rating\":2692,\"fideId\":1039784,\"team\":\"SC
+        Viernheim\",\"fed\":\"NED\",\"played\":6,\"score\":4.5},{\"name\":\"Meier,
+        Georg\",\"title\":\"GM\",\"rating\":2596,\"fideId\":4675789,\"team\":\"SC
+        Viernheim\",\"fed\":\"URU\",\"played\":4,\"score\":3.5},{\"name\":\"Amin,
+        Bassem\",\"title\":\"GM\",\"rating\":2636,\"fideId\":10601457,\"team\":\"SC
+        Viernheim\",\"fed\":\"EGY\",\"played\":8,\"score\":7},{\"name\":\"Aravindh,
+        Chithambaram VR.\",\"title\":\"GM\",\"rating\":2703,\"fideId\":5072786,\"team\":\"SC
+        Viernheim\",\"fed\":\"IND\",\"played\":4,\"score\":2}],\"averageRating\":2622},{\"name\":\"OSG
+        Baden-Baden\",\"mp\":7.5,\"gp\":43,\"matches\":[{\"roundId\":\"SY7G4X9F\",\"opponent\":\"FC
+        St. Pauli\",\"points\":\"1\",\"mp\":1,\"gp\":5},{\"roundId\":\"20EKKqrN\",\"opponent\":\"Hamburger
+        SK\",\"points\":\"1\",\"mp\":1,\"gp\":6},{\"roundId\":\"IZZCW7IG\",\"opponent\":\"SV
+        Deggendorf\",\"points\":\"1\",\"mp\":1,\"gp\":4.5},{\"roundId\":\"Woyg2kpP\",\"opponent\":\"FC
+        Bayern M\xFCnchen\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"AlyVP7Tj\",\"opponent\":\"SV
+        Werder Bremen\",\"points\":\"1\",\"mp\":1,\"gp\":5.5},{\"roundId\":\"SR1eddMe\",\"opponent\":\"SK
+        Kirchweyhe\",\"points\":\"1\",\"mp\":1,\"gp\":4.5},{\"roundId\":\"nRVdmVdP\",\"opponent\":\"USV
+        TU Dresden\",\"points\":\"1\",\"mp\":1,\"gp\":6.5},{\"roundId\":\"2hgbLbso\",\"opponent\":\"SF
+        Berlin\",\"points\":\"1\",\"mp\":1,\"gp\":7}],\"players\":[{\"name\":\"Vachier-Lagrave,
+        Maxime\",\"title\":\"GM\",\"rating\":2734,\"fideId\":623539,\"team\":\"OSG
+        Baden-Baden\",\"fed\":\"FRA\",\"played\":2,\"score\":1},{\"name\":\"Caruana,
+        Fabiano\",\"title\":\"GM\",\"rating\":2795,\"fideId\":2020009,\"team\":\"OSG
+        Baden-Baden\",\"fed\":\"USA\",\"played\":3,\"score\":1.5},{\"name\":\"Vitiugov,
+        Nikita\",\"title\":\"GM\",\"rating\":2666,\"fideId\":4152956,\"team\":\"OSG
+        Baden-Baden\",\"fed\":\"ENG\",\"played\":7,\"score\":3.5},{\"name\":\"Wojtaszek,
+        Radoslaw\",\"title\":\"GM\",\"rating\":2661,\"fideId\":1118358,\"team\":\"OSG
+        Baden-Baden\",\"fed\":\"POL\",\"played\":8,\"score\":6},{\"name\":\"Hagner,
+        Bennet\",\"title\":\"IM\",\"rating\":2451,\"fideId\":16224477,\"team\":\"OSG
+        Baden-Baden\",\"fed\":\"GER\",\"played\":6,\"score\":3.5},{\"name\":\"Rapport,
+        Richard\",\"title\":\"GM\",\"rating\":2711,\"fideId\":738590,\"team\":\"OSG
+        Baden-Baden\",\"fed\":\"HUN\",\"played\":4,\"score\":3},{\"name\":\"Kasimdzhanov,
+        Rustam\",\"title\":\"GM\",\"rating\":2675,\"fideId\":14200244,\"team\":\"OSG
+        Baden-Baden\",\"fed\":\"UZB\",\"played\":6,\"score\":3},{\"name\":\"Shirov,
+        Alexei\",\"title\":\"GM\",\"rating\":2609,\"fideId\":2209390,\"team\":\"OSG
+        Baden-Baden\",\"fed\":\"ESP\",\"played\":4,\"score\":3.5},{\"name\":\"Nihal
+        Sarin\",\"title\":\"GM\",\"rating\":2716,\"fideId\":25092340,\"team\":\"OSG
+        Baden-Baden\",\"fed\":\"IND\",\"played\":2,\"score\":2},{\"name\":\"Kocharin,
+        Timur\",\"title\":\"FM\",\"rating\":2332,\"fideId\":16240936,\"team\":\"OSG
+        Baden-Baden\",\"fed\":\"GER\",\"played\":2,\"score\":1.5},{\"name\":\"Bacrot,
+        Etienne\",\"title\":\"GM\",\"rating\":2637,\"fideId\":605506,\"team\":\"OSG
+        Baden-Baden\",\"fed\":\"FRA\",\"played\":8,\"score\":6},{\"name\":\"Keymer,
+        Vincent\",\"title\":\"GM\",\"rating\":2751,\"fideId\":12940690,\"team\":\"OSG
+        Baden-Baden\",\"fed\":\"GER\",\"played\":2,\"score\":1},{\"name\":\"Sindarov,
+        Javokhir\",\"title\":\"GM\",\"rating\":2722,\"fideId\":14205483,\"team\":\"OSG
+        Baden-Baden\",\"fed\":\"UZB\",\"played\":2,\"score\":1.5},{\"name\":\"Donchenko,
+        Alexander\",\"title\":\"GM\",\"rating\":2624,\"fideId\":24603295,\"team\":\"OSG
+        Baden-Baden\",\"fed\":\"GER\",\"played\":8,\"score\":6}],\"averageRating\":2649},{\"name\":\"Sfr.
+        Wolfhagen\",\"mp\":6.5,\"gp\":38.5,\"matches\":[{\"roundId\":\"SY7G4X9F\",\"opponent\":\"USV
+        TU Dresden\",\"points\":\"1\",\"mp\":1,\"gp\":5.5},{\"roundId\":\"20EKKqrN\",\"opponent\":\"SF
+        Berlin\",\"points\":\"1\",\"mp\":1,\"gp\":6},{\"roundId\":\"IZZCW7IG\",\"opponent\":\"Schachfreunde
+        Deizisau\",\"points\":\"0\",\"mp\":0,\"gp\":3},{\"roundId\":\"Woyg2kpP\",\"opponent\":\"MSA
+        Zugzwang\",\"points\":\"1\",\"mp\":1,\"gp\":5.5},{\"roundId\":\"AlyVP7Tj\",\"opponent\":\"Hamburger
+        SK\",\"points\":\"1\",\"mp\":1,\"gp\":4.5},{\"roundId\":\"SR1eddMe\",\"opponent\":\"FC
+        St. Pauli\",\"points\":\"1\",\"mp\":1,\"gp\":5},{\"roundId\":\"nRVdmVdP\",\"opponent\":\"D\xFCsseldorfer
+        SK\",\"points\":\"1\",\"mp\":1,\"gp\":5},{\"roundId\":\"2hgbLbso\",\"opponent\":\"SG
+        Solingen\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4}],\"players\":[{\"name\":\"Volokitin,
+        Andrei\",\"title\":\"GM\",\"rating\":2628,\"fideId\":14107090,\"team\":\"Sfr.
+        Wolfhagen\",\"fed\":\"UKR\",\"played\":8,\"score\":5},{\"name\":\"Motylev,
+        Alexander\",\"title\":\"GM\",\"rating\":2573,\"fideId\":4121830,\"team\":\"Sfr.
+        Wolfhagen\",\"fed\":\"ROU\",\"played\":4,\"score\":1},{\"name\":\"Samunenkov,
+        Ihor\",\"title\":\"GM\",\"rating\":2550,\"fideId\":14187086,\"team\":\"Sfr.
+        Wolfhagen\",\"fed\":\"UKR\",\"played\":6,\"score\":4},{\"name\":\"Baklan,
+        Vladimir\",\"title\":\"GM\",\"rating\":2552,\"fideId\":14102196,\"team\":\"Sfr.
+        Wolfhagen\",\"fed\":\"UKR\",\"played\":2,\"score\":1.5},{\"name\":\"Ponomariov,
+        Ruslan\",\"title\":\"GM\",\"rating\":2622,\"fideId\":14103320,\"team\":\"Sfr.
+        Wolfhagen\",\"fed\":\"UKR\",\"played\":6,\"score\":4},{\"name\":\"Bogdanov,
+        Egor\",\"title\":\"GM\",\"rating\":2500,\"fideId\":14119137,\"team\":\"Sfr.
+        Wolfhagen\",\"fed\":\"UKR\",\"played\":2,\"score\":1.5},{\"name\":\"Petrovskiy,
+        Vadym\",\"title\":\"IM\",\"rating\":2433,\"fideId\":14165210,\"team\":\"Sfr.
+        Wolfhagen\",\"fed\":\"GER\",\"played\":2,\"score\":1},{\"name\":\"Kryvoruchko,
+        Yuriy\",\"title\":\"GM\",\"rating\":2632,\"fideId\":14109182,\"team\":\"Sfr.
+        Wolfhagen\",\"fed\":\"UKR\",\"played\":6,\"score\":3},{\"name\":\"Onyshchuk,
+        Volodymyr\",\"title\":\"GM\",\"rating\":2607,\"fideId\":14114038,\"team\":\"Sfr.
+        Wolfhagen\",\"fed\":\"UKR\",\"played\":8,\"score\":5},{\"name\":\"Peng, Li
+        Min\",\"title\":\"GM\",\"rating\":2530,\"fideId\":14112620,\"team\":\"Sfr.
+        Wolfhagen\",\"fed\":\"SUI\",\"played\":2,\"score\":1},{\"name\":\"Kuzubov,
+        Yuriy\",\"title\":\"GM\",\"rating\":2600,\"fideId\":14112906,\"team\":\"Sfr.
+        Wolfhagen\",\"fed\":\"UKR\",\"played\":6,\"score\":4},{\"name\":\"Vetoshko,
+        Volodymyr\",\"title\":\"GM\",\"rating\":2514,\"fideId\":14122480,\"team\":\"Sfr.
+        Wolfhagen\",\"fed\":\"UKR\",\"played\":4,\"score\":2},{\"name\":\"Galperin,
+        Platon\",\"title\":\"GM\",\"rating\":2494,\"fideId\":14165414,\"team\":\"Sfr.
+        Wolfhagen\",\"fed\":\"SWE\",\"played\":2,\"score\":1.5},{\"name\":\"Chigaev,
+        Maksim\",\"title\":\"GM\",\"rating\":2626,\"fideId\":4108116,\"team\":\"Sfr.
+        Wolfhagen\",\"fed\":\"ESP\",\"played\":6,\"score\":4}],\"averageRating\":2562},{\"name\":\"FC
+        Bayern M\xFCnchen\",\"mp\":5,\"gp\":34.5,\"matches\":[{\"roundId\":\"SY7G4X9F\",\"opponent\":\"SG
+        Solingen\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"20EKKqrN\",\"opponent\":\"D\xFCsseldorfer
+        SK\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"IZZCW7IG\",\"opponent\":\"SC
+        Heimbach-Weis-Neuwied\",\"points\":\"1\",\"mp\":1,\"gp\":4.5},{\"roundId\":\"Woyg2kpP\",\"opponent\":\"OSG
+        Baden-Baden\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"AlyVP7Tj\",\"opponent\":\"MSA
+        Zugzwang\",\"points\":\"1\",\"mp\":1,\"gp\":4.5},{\"roundId\":\"SR1eddMe\",\"opponent\":\"Schachfreunde
+        Deizisau\",\"points\":\"1\",\"mp\":1,\"gp\":6},{\"roundId\":\"nRVdmVdP\",\"opponent\":\"SK
+        Kirchweyhe\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"2hgbLbso\",\"opponent\":\"SV
+        Werder Bremen\",\"points\":\"0\",\"mp\":0,\"gp\":3.5}],\"players\":[{\"name\":\"Dragnev,
+        Valentin\",\"title\":\"GM\",\"rating\":2539,\"fideId\":1634852,\"team\":\"FC
+        Bayern M\xFCnchen\",\"fed\":\"AUT\",\"played\":6,\"score\":3},{\"name\":\"Subelj,
+        Jan\",\"title\":\"GM\",\"rating\":2537,\"fideId\":14618583,\"team\":\"FC Bayern
+        M\xFCnchen\",\"fed\":\"SLO\",\"played\":6,\"score\":3.5},{\"name\":\"Lindgren,
+        Philip\",\"title\":\"IM\",\"rating\":2384,\"fideId\":1713230,\"team\":\"FC
+        Bayern M\xFCnchen\",\"fed\":\"SWE\",\"played\":4,\"score\":1},{\"name\":\"Santos
+        Latasa, Jaime\",\"title\":\"GM\",\"rating\":2615,\"fideId\":2293307,\"team\":\"FC
+        Bayern M\xFCnchen\",\"fed\":\"ESP\",\"played\":4,\"score\":1.5},{\"name\":\"Bischoff,
+        Klaus\",\"title\":\"GM\",\"rating\":2428,\"fideId\":4600045,\"team\":\"FC
+        Bayern M\xFCnchen\",\"fed\":\"GER\",\"played\":6,\"score\":2},{\"name\":\"Kurmann,
+        Oliver\",\"title\":\"IM\",\"rating\":2392,\"fideId\":1308173,\"team\":\"FC
+        Bayern M\xFCnchen\",\"fed\":\"SUI\",\"played\":2,\"score\":0.5},{\"name\":\"Girel,
+        Joseph\",\"title\":\"GM\",\"rating\":2501,\"fideId\":36033561,\"team\":\"FC
+        Bayern M\xFCnchen\",\"fed\":\"FRA\",\"played\":4,\"score\":3},{\"name\":\"Johansson,
+        Linus\",\"title\":\"IM\",\"rating\":2412,\"fideId\":1711113,\"team\":\"FC
+        Bayern M\xFCnchen\",\"fed\":\"SWE\",\"played\":4,\"score\":2},{\"name\":\"Alekseenko,
+        Kirill\",\"title\":\"GM\",\"rating\":2674,\"fideId\":4135539,\"team\":\"FC
+        Bayern M\xFCnchen\",\"fed\":\"AUT\",\"played\":8,\"score\":5.5},{\"name\":\"Idani,
+        Pouya\",\"title\":\"GM\",\"rating\":2599,\"fideId\":12510130,\"team\":\"FC
+        Bayern M\xFCnchen\",\"fed\":\"IRI\",\"played\":6,\"score\":3},{\"name\":\"Alonso
+        Rosell, Alvar\",\"title\":\"GM\",\"rating\":2548,\"fideId\":2270544,\"team\":\"FC
+        Bayern M\xFCnchen\",\"fed\":\"ESP\",\"played\":6,\"score\":4.5},{\"name\":\"Pichot,
+        Alan\",\"title\":\"GM\",\"rating\":2588,\"fideId\":110973,\"team\":\"FC Bayern
+        M\xFCnchen\",\"fed\":\"ESP\",\"played\":4,\"score\":2.5},{\"name\":\"Abasov,
+        Nijat\",\"title\":\"GM\",\"rating\":2587,\"fideId\":13402960,\"team\":\"FC
+        Bayern M\xFCnchen\",\"fed\":\"AZE\",\"played\":2,\"score\":1.5},{\"name\":\"Fedoseev,
+        Vladimir\",\"title\":\"GM\",\"rating\":2705,\"fideId\":24130737,\"team\":\"FC
+        Bayern M\xFCnchen\",\"fed\":\"SLO\",\"played\":2,\"score\":1}],\"averageRating\":2536},{\"name\":\"SV
+        Werder Bremen\",\"mp\":5,\"gp\":32,\"matches\":[{\"roundId\":\"SY7G4X9F\",\"opponent\":\"Schachfreunde
+        Deizisau\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"20EKKqrN\",\"opponent\":\"MSA
+        Zugzwang\",\"points\":\"1\",\"mp\":1,\"gp\":4.5},{\"roundId\":\"IZZCW7IG\",\"opponent\":\"D\xFCsseldorfer
+        SK\",\"points\":\"1\",\"mp\":1,\"gp\":5.5},{\"roundId\":\"Woyg2kpP\",\"opponent\":\"SG
+        Solingen\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"AlyVP7Tj\",\"opponent\":\"OSG
+        Baden-Baden\",\"points\":\"0\",\"mp\":0,\"gp\":2.5},{\"roundId\":\"SR1eddMe\",\"opponent\":\"SC
+        Heimbach-Weis-Neuwied\",\"points\":\"0\",\"mp\":0,\"gp\":2.5},{\"roundId\":\"nRVdmVdP\",\"opponent\":\"SV
+        Deggendorf\",\"points\":\"1\",\"mp\":1,\"gp\":4.5},{\"roundId\":\"2hgbLbso\",\"opponent\":\"FC
+        Bayern M\xFCnchen\",\"points\":\"1\",\"mp\":1,\"gp\":4.5}],\"players\":[{\"name\":\"Babula,
+        Vlastimil\",\"title\":\"GM\",\"rating\":2496,\"fideId\":301264,\"team\":\"SV
+        Werder Bremen\",\"fed\":\"CZE\",\"played\":4,\"score\":2.5},{\"name\":\"McShane,
+        Luke J\",\"title\":\"GM\",\"rating\":2615,\"fideId\":404853,\"team\":\"SV
+        Werder Bremen\",\"fed\":\"ENG\",\"played\":6,\"score\":2},{\"name\":\"Grigorian,
+        Spartak\",\"title\":\"IM\",\"rating\":2430,\"fideId\":24661490,\"team\":\"SV
+        Werder Bremen\",\"fed\":\"GER\",\"played\":2,\"score\":0.5},{\"name\":\"Martirosyan,
+        Haik M.\",\"title\":\"GM\",\"rating\":2628,\"fideId\":13306553,\"team\":\"SV
+        Werder Bremen\",\"fed\":\"ARM\",\"played\":6,\"score\":3.5},{\"name\":\"Cheng,
+        Bobby\",\"title\":\"GM\",\"rating\":2583,\"fideId\":4300033,\"team\":\"SV
+        Werder Bremen\",\"fed\":\"AUS\",\"played\":6,\"score\":2.5},{\"name\":\"Schulze,
+        Lara\",\"title\":\"FM\",\"rating\":2327,\"fideId\":12956830,\"team\":\"SV
+        Werder Bremen\",\"fed\":\"GER\",\"played\":2,\"score\":1.5},{\"name\":\"Areshchenko,
+        Alexander\",\"title\":\"GM\",\"rating\":2598,\"fideId\":14109530,\"team\":\"SV
+        Werder Bremen\",\"fed\":\"UKR\",\"played\":2,\"score\":1.5},{\"name\":\"Efimenko,
+        Zahar\",\"title\":\"GM\",\"rating\":2565,\"fideId\":14107201,\"team\":\"SV
+        Werder Bremen\",\"fed\":\"UKR\",\"played\":8,\"score\":4},{\"name\":\"Hracek,
+        Zbynek\",\"title\":\"GM\",\"rating\":2540,\"fideId\":300071,\"team\":\"SV
+        Werder Bremen\",\"fed\":\"CZE\",\"played\":4,\"score\":2.5},{\"name\":\"Gumularz,
+        Szymon\",\"title\":\"GM\",\"rating\":2606,\"fideId\":1188062,\"team\":\"SV
+        Werder Bremen\",\"fed\":\"POL\",\"played\":4,\"score\":1},{\"name\":\"Colbow,
+        Collin\",\"title\":\"IM\",\"rating\":2440,\"fideId\":16201132,\"team\":\"SV
+        Werder Bremen\",\"fed\":\"GER\",\"played\":2,\"score\":0.5},{\"name\":\"Fressinet,
+        Laurent\",\"title\":\"GM\",\"rating\":2602,\"fideId\":608742,\"team\":\"SV
+        Werder Bremen\",\"fed\":\"FRA\",\"played\":4,\"score\":2},{\"name\":\"Ivic,
+        Velimir\",\"title\":\"GM\",\"rating\":2623,\"fideId\":950122,\"team\":\"SV
+        Werder Bremen\",\"fed\":\"SRB\",\"played\":4,\"score\":1},{\"name\":\"Van
+        Foreest, Lucas\",\"title\":\"GM\",\"rating\":2513,\"fideId\":1039792,\"team\":\"SV
+        Werder Bremen\",\"fed\":\"NED\",\"played\":4,\"score\":3.5},{\"name\":\"Wachinger,
+        Nikolas\",\"title\":\"IM\",\"rating\":2450,\"fideId\":12962791,\"team\":\"SV
+        Werder Bremen\",\"fed\":\"GER\",\"played\":4,\"score\":2},{\"name\":\"Reuker,
+        Jari\",\"title\":\"IM\",\"rating\":2380,\"fideId\":12909300,\"team\":\"SV
+        Werder Bremen\",\"fed\":\"GER\",\"played\":2,\"score\":1.5}],\"averageRating\":2525},{\"name\":\"SG
+        Solingen\",\"mp\":4.5,\"gp\":35,\"matches\":[{\"roundId\":\"SY7G4X9F\",\"opponent\":\"FC
+        Bayern M\xFCnchen\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"20EKKqrN\",\"opponent\":\"SV
+        Deggendorf\",\"points\":\"1\",\"mp\":1,\"gp\":4.5},{\"roundId\":\"IZZCW7IG\",\"opponent\":\"SK
+        Kirchweyhe\",\"points\":\"0\",\"mp\":0,\"gp\":3.5},{\"roundId\":\"Woyg2kpP\",\"opponent\":\"SV
+        Werder Bremen\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"AlyVP7Tj\",\"opponent\":\"SF
+        Berlin\",\"points\":\"1\",\"mp\":1,\"gp\":5},{\"roundId\":\"SR1eddMe\",\"opponent\":\"USV
+        TU Dresden\",\"points\":\"1\",\"mp\":1,\"gp\":6.5},{\"roundId\":\"nRVdmVdP\",\"opponent\":\"SC
+        Viernheim\",\"points\":\"0\",\"mp\":0,\"gp\":3.5},{\"roundId\":\"2hgbLbso\",\"opponent\":\"Sfr.
+        Wolfhagen\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4}],\"players\":[{\"name\":\"Van
+        Wely, Loek\",\"title\":\"GM\",\"rating\":2625,\"fideId\":1000268,\"team\":\"SG
+        Solingen\",\"fed\":\"NED\",\"played\":6,\"score\":4.5},{\"name\":\"Harikrishna,
+        Pentala\",\"title\":\"GM\",\"rating\":2704,\"fideId\":5007003,\"team\":\"SG
+        Solingen\",\"fed\":\"IND\",\"played\":4,\"score\":1.5},{\"name\":\"L'Ami,
+        Erwin\",\"title\":\"GM\",\"rating\":2616,\"fideId\":1007998,\"team\":\"SG
+        Solingen\",\"fed\":\"NED\",\"played\":8,\"score\":4},{\"name\":\"Krastev,
+        Alexander\",\"title\":\"IM\",\"rating\":2424,\"fideId\":12989983,\"team\":\"SG
+        Solingen\",\"fed\":\"GER\",\"played\":6,\"score\":3.5},{\"name\":\"Navara,
+        David\",\"title\":\"GM\",\"rating\":2653,\"fideId\":309095,\"team\":\"SG Solingen\",\"fed\":\"CZE\",\"played\":6,\"score\":4},{\"name\":\"Wegerle,
+        Joerg\",\"title\":\"IM\",\"rating\":2405,\"fideId\":4644743,\"team\":\"SG
+        Solingen\",\"fed\":\"GER\",\"played\":2,\"score\":1},{\"name\":\"Nikolic,
+        Predrag\",\"title\":\"GM\",\"rating\":2554,\"fideId\":14400014,\"team\":\"SG
+        Solingen\",\"fed\":\"BIH\",\"played\":2,\"score\":0.5},{\"name\":\"Naumann,
+        Alexander\",\"title\":\"GM\",\"rating\":2469,\"fideId\":4623169,\"team\":\"SG
+        Solingen\",\"fed\":\"GER\",\"played\":6,\"score\":4},{\"name\":\"Handke, Florian,
+        Dr.\",\"title\":\"GM\",\"rating\":2526,\"fideId\":4634527,\"team\":\"SG Solingen\",\"fed\":\"GER\",\"played\":6,\"score\":2.5},{\"name\":\"Ragger,
+        Markus\",\"title\":\"GM\",\"rating\":2563,\"fideId\":1610856,\"team\":\"SG
+        Solingen\",\"fed\":\"AUT\",\"played\":6,\"score\":3.5},{\"name\":\"Warmerdam,
+        Max\",\"title\":\"GM\",\"rating\":2591,\"fideId\":1048104,\"team\":\"SG Solingen\",\"fed\":\"NED\",\"played\":6,\"score\":3},{\"name\":\"Smeets,
+        Jan\",\"title\":\"GM\",\"rating\":2566,\"fideId\":1007246,\"team\":\"SG Solingen\",\"fed\":\"NED\",\"played\":4,\"score\":1.5},{\"name\":\"Schaefer,
+        Markus\",\"title\":\"IM\",\"rating\":2360,\"fideId\":4605551,\"team\":\"SG
+        Solingen\",\"fed\":\"GER\",\"played\":2,\"score\":1.5}],\"averageRating\":2543},{\"name\":\"SK
+        Kirchweyhe\",\"mp\":4.5,\"gp\":32,\"matches\":[{\"roundId\":\"SY7G4X9F\",\"opponent\":\"MSA
+        Zugzwang\",\"points\":\"1\",\"mp\":1,\"gp\":4.5},{\"roundId\":\"20EKKqrN\",\"opponent\":\"Schachfreunde
+        Deizisau\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"IZZCW7IG\",\"opponent\":\"SG
+        Solingen\",\"points\":\"1\",\"mp\":1,\"gp\":4.5},{\"roundId\":\"Woyg2kpP\",\"opponent\":\"D\xFCsseldorfer
+        SK\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"AlyVP7Tj\",\"opponent\":\"SC
+        Heimbach-Weis-Neuwied\",\"points\":\"1\",\"mp\":1,\"gp\":4.5},{\"roundId\":\"SR1eddMe\",\"opponent\":\"OSG
+        Baden-Baden\",\"points\":\"0\",\"mp\":0,\"gp\":3.5},{\"roundId\":\"nRVdmVdP\",\"opponent\":\"FC
+        Bayern M\xFCnchen\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"2hgbLbso\",\"opponent\":\"SV
+        Deggendorf\",\"points\":\"0\",\"mp\":0,\"gp\":3}],\"players\":[{\"name\":\"Zelcic,
+        Robert\",\"title\":\"GM\",\"rating\":2448,\"fideId\":14500310,\"team\":\"SK
+        Kirchweyhe\",\"fed\":\"CRO\",\"played\":2,\"score\":1},{\"name\":\"Martinovic,
+        Sasa\",\"title\":\"GM\",\"rating\":2551,\"fideId\":14509792,\"team\":\"SK
+        Kirchweyhe\",\"fed\":\"CRO\",\"played\":8,\"score\":4},{\"name\":\"Predojevic,
+        Borki\",\"title\":\"GM\",\"rating\":2562,\"fideId\":930849,\"team\":\"SK Kirchweyhe\",\"fed\":\"BIH\",\"played\":6,\"score\":2.5},{\"name\":\"Markus,
+        Robert\",\"title\":\"GM\",\"rating\":2529,\"fideId\":921637,\"team\":\"SK
+        Kirchweyhe\",\"fed\":\"SRB\",\"played\":6,\"score\":2.5},{\"name\":\"Culum,
+        Sanjin\",\"title\":\"IM\",\"rating\":2444,\"fideId\":14420937,\"team\":\"SK
+        Kirchweyhe\",\"fed\":\"BIH\",\"played\":2,\"score\":1.5},{\"name\":\"Stevic,
+        Hrvoje\",\"title\":\"GM\",\"rating\":2526,\"fideId\":14502569,\"team\":\"SK
+        Kirchweyhe\",\"fed\":\"CRO\",\"played\":8,\"score\":5.5},{\"name\":\"Van den
+        Doel, Erik\",\"title\":\"GM\",\"rating\":2559,\"fideId\":1003720,\"team\":\"SK
+        Kirchweyhe\",\"fed\":\"NED\",\"played\":8,\"score\":3.5},{\"name\":\"Predke,
+        Alexandr\",\"title\":\"GM\",\"rating\":2616,\"fideId\":24107581,\"team\":\"SK
+        Kirchweyhe\",\"fed\":\"SRB\",\"played\":6,\"score\":3.5},{\"name\":\"Brkic,
+        Ante\",\"title\":\"GM\",\"rating\":2594,\"fideId\":14506688,\"team\":\"SK
+        Kirchweyhe\",\"fed\":\"CRO\",\"played\":8,\"score\":4},{\"name\":\"Saric,
+        Ivan\",\"title\":\"GM\",\"rating\":2655,\"fideId\":14508150,\"team\":\"SK
+        Kirchweyhe\",\"fed\":\"CRO\",\"played\":8,\"score\":3},{\"name\":\"Jovanovic,
+        Zoran\",\"title\":\"GM\",\"rating\":2500,\"fideId\":14505320,\"team\":\"SK
+        Kirchweyhe\",\"fed\":\"CRO\",\"played\":2,\"score\":1}],\"averageRating\":2544},{\"name\":\"FC
+        St. Pauli\",\"mp\":3.5,\"gp\":30,\"matches\":[{\"roundId\":\"SY7G4X9F\",\"opponent\":\"OSG
+        Baden-Baden\",\"points\":\"0\",\"mp\":0,\"gp\":3},{\"roundId\":\"20EKKqrN\",\"opponent\":\"SC
+        Heimbach-Weis-Neuwied\",\"points\":\"1\",\"mp\":1,\"gp\":5},{\"roundId\":\"IZZCW7IG\",\"opponent\":\"USV
+        TU Dresden\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"Woyg2kpP\",\"opponent\":\"SF
+        Berlin\",\"points\":\"1\",\"mp\":1,\"gp\":4.5},{\"roundId\":\"AlyVP7Tj\",\"opponent\":\"SC
+        Viernheim\",\"points\":\"0\",\"mp\":0,\"gp\":3},{\"roundId\":\"SR1eddMe\",\"opponent\":\"Sfr.
+        Wolfhagen\",\"points\":\"0\",\"mp\":0,\"gp\":3},{\"roundId\":\"nRVdmVdP\",\"opponent\":\"Schachfreunde
+        Deizisau\",\"points\":\"1\",\"mp\":1,\"gp\":4.5},{\"roundId\":\"2hgbLbso\",\"opponent\":\"MSA
+        Zugzwang\",\"points\":\"0\",\"mp\":0,\"gp\":3}],\"players\":[{\"name\":\"Socko,
+        Bartosz\",\"title\":\"GM\",\"rating\":2577,\"fideId\":1107038,\"team\":\"FC
+        St. Pauli\",\"fed\":\"POL\",\"played\":6,\"score\":3.5},{\"name\":\"Feuerstack,
+        Aljoscha\",\"title\":\"IM\",\"rating\":2447,\"fideId\":4681932,\"team\":\"FC
+        St. Pauli\",\"fed\":\"GER\",\"played\":2,\"score\":1.5},{\"name\":\"Maurizzi,
+        MarcAndria\",\"title\":\"GM\",\"rating\":2610,\"fideId\":36083534,\"team\":\"FC
+        St. Pauli\",\"fed\":\"FRA\",\"played\":2,\"score\":0.5},{\"name\":\"Andersen,
+        Mads\",\"title\":\"GM\",\"rating\":2564,\"fideId\":1413864,\"team\":\"FC St.
+        Pauli\",\"fed\":\"DEN\",\"played\":8,\"score\":5.5},{\"name\":\"Krause, Jonah\",\"title\":\"FM\",\"rating\":2321,\"fideId\":12907910,\"team\":\"FC
+        St. Pauli\",\"fed\":\"GER\",\"played\":4,\"score\":2},{\"name\":\"Bjerre,
+        Jonas Buhl\",\"title\":\"GM\",\"rating\":2651,\"fideId\":1444948,\"team\":\"FC
+        St. Pauli\",\"fed\":\"DEN\",\"played\":8,\"score\":4},{\"name\":\"Thybo, Jesper
+        Sondergaard\",\"title\":\"GM\",\"rating\":2573,\"fideId\":1438832,\"team\":\"FC
+        St. Pauli\",\"fed\":\"DEN\",\"played\":6,\"score\":3.5},{\"name\":\"Sawatzki,
+        Frank\",\"title\":\"FM\",\"rating\":2336,\"fideId\":4613600,\"team\":\"FC
+        St. Pauli\",\"fed\":\"GER\",\"played\":2,\"score\":0.5},{\"name\":\"Amar,
+        Elham\",\"title\":\"GM\",\"rating\":2584,\"fideId\":1533533,\"team\":\"FC
+        St. Pauli\",\"fed\":\"NOR\",\"played\":4,\"score\":1.5},{\"name\":\"Ertan,
+        Can\",\"title\":\"IM\",\"rating\":2367,\"fideId\":6306330,\"team\":\"FC St.
+        Pauli\",\"fed\":\"TUR\",\"played\":2,\"score\":0.5},{\"name\":\"Krause, Benedict\",\"title\":\"IM\",\"rating\":2421,\"fideId\":12917990,\"team\":\"FC
+        St. Pauli\",\"fed\":\"GER\",\"played\":6,\"score\":1.5},{\"name\":\"Theodorou,
+        Nikolas\",\"title\":\"GM\",\"rating\":2646,\"fideId\":4262875,\"team\":\"FC
+        St. Pauli\",\"fed\":\"GRE\",\"played\":6,\"score\":2},{\"name\":\"Nielsen,
+        Peter Heine\",\"title\":\"GM\",\"rating\":2617,\"fideId\":1400355,\"team\":\"FC
+        St. Pauli\",\"fed\":\"DEN\",\"played\":2,\"score\":1},{\"name\":\"Janik, Igor\",\"title\":\"GM\",\"rating\":2528,\"fideId\":1159259,\"team\":\"FC
+        St. Pauli\",\"fed\":\"POL\",\"played\":6,\"score\":2.5}],\"averageRating\":2517},{\"name\":\"Hamburger
+        SK\",\"mp\":3.5,\"gp\":29,\"matches\":[{\"roundId\":\"SY7G4X9F\",\"opponent\":\"SC
+        Heimbach-Weis-Neuwied\",\"points\":\"0\",\"mp\":0,\"gp\":3.5},{\"roundId\":\"20EKKqrN\",\"opponent\":\"OSG
+        Baden-Baden\",\"points\":\"0\",\"mp\":0,\"gp\":2},{\"roundId\":\"IZZCW7IG\",\"opponent\":\"SF
+        Berlin\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"Woyg2kpP\",\"opponent\":\"USV
+        TU Dresden\",\"points\":\"1\",\"mp\":1,\"gp\":5},{\"roundId\":\"AlyVP7Tj\",\"opponent\":\"Sfr.
+        Wolfhagen\",\"points\":\"0\",\"mp\":0,\"gp\":3.5},{\"roundId\":\"SR1eddMe\",\"opponent\":\"SC
+        Viernheim\",\"points\":\"0\",\"mp\":0,\"gp\":2},{\"roundId\":\"nRVdmVdP\",\"opponent\":\"MSA
+        Zugzwang\",\"points\":\"1\",\"mp\":1,\"gp\":4.5},{\"roundId\":\"2hgbLbso\",\"opponent\":\"Schachfreunde
+        Deizisau\",\"points\":\"1\",\"mp\":1,\"gp\":4.5}],\"players\":[{\"name\":\"Gustafsson,
+        Jan\",\"title\":\"GM\",\"rating\":2591,\"fideId\":4625498,\"team\":\"Hamburger
+        SK\",\"fed\":\"GER\",\"played\":6,\"score\":2.5},{\"name\":\"Svane, Frederik\",\"title\":\"GM\",\"rating\":2643,\"fideId\":12923044,\"team\":\"Hamburger
+        SK\",\"fed\":\"GER\",\"played\":6,\"score\":2},{\"name\":\"Engel, Luis\",\"title\":\"GM\",\"rating\":2580,\"fideId\":12961523,\"team\":\"Hamburger
+        SK\",\"fed\":\"GER\",\"played\":6,\"score\":4.5},{\"name\":\"Mendonca, Leon
+        Luke\",\"title\":\"GM\",\"rating\":2615,\"fideId\":35028561,\"team\":\"Hamburger
+        SK\",\"fed\":\"IND\",\"played\":2,\"score\":0.5},{\"name\":\"Garner, Isaac\",\"rating\":2387,\"fideId\":16239261,\"team\":\"Hamburger
+        SK\",\"fed\":\"GER\",\"played\":2,\"score\":0},{\"name\":\"Kempinski, Robert\",\"title\":\"GM\",\"rating\":2545,\"fideId\":1105663,\"team\":\"Hamburger
+        SK\",\"fed\":\"POL\",\"played\":6,\"score\":3},{\"name\":\"Kramer, Julian\",\"title\":\"GM\",\"rating\":2487,\"fideId\":12921742,\"team\":\"Hamburger
+        SK\",\"fed\":\"GER\",\"played\":2,\"score\":1},{\"name\":\"Peyrer, Konstantin\",\"title\":\"IM\",\"rating\":2488,\"fideId\":1640879,\"team\":\"Hamburger
+        SK\",\"fed\":\"AUT\",\"played\":6,\"score\":3},{\"name\":\"Papp, Gabor\",\"title\":\"GM\",\"rating\":2498,\"fideId\":718602,\"team\":\"Hamburger
+        SK\",\"fed\":\"HUN\",\"played\":6,\"score\":3.5},{\"name\":\"Huschenbeth,
+        Niclas\",\"title\":\"GM\",\"rating\":2591,\"fideId\":24604747,\"team\":\"Hamburger
+        SK\",\"fed\":\"GER\",\"played\":2,\"score\":0.5},{\"name\":\"Woelk, Tom-Frederic\",\"title\":\"IM\",\"rating\":2405,\"fideId\":12993077,\"team\":\"Hamburger
+        SK\",\"fed\":\"GER\",\"played\":2,\"score\":1},{\"name\":\"Weihrauch, Jakob\",\"title\":\"FM\",\"rating\":2247,\"fideId\":16210115,\"team\":\"Hamburger
+        SK\",\"fed\":\"GER\",\"played\":2,\"score\":0},{\"name\":\"Heinemann, Thies\",\"title\":\"GM\",\"rating\":2418,\"fideId\":4601556,\"team\":\"Hamburger
+        SK\",\"fed\":\"GER\",\"played\":6,\"score\":2},{\"name\":\"Svane, Rasmus\",\"title\":\"GM\",\"rating\":2620,\"fideId\":4657101,\"team\":\"Hamburger
+        SK\",\"fed\":\"GER\",\"played\":8,\"score\":4.5},{\"name\":\"Grandelius, Nils\",\"title\":\"GM\",\"rating\":2664,\"fideId\":1710400,\"team\":\"Hamburger
+        SK\",\"fed\":\"SWE\",\"played\":2,\"score\":1}],\"averageRating\":2519},{\"name\":\"SC
+        Heimbach-Weis-Neuwied\",\"mp\":3,\"gp\":31,\"matches\":[{\"roundId\":\"SY7G4X9F\",\"opponent\":\"Hamburger
+        SK\",\"points\":\"1\",\"mp\":1,\"gp\":4.5},{\"roundId\":\"20EKKqrN\",\"opponent\":\"FC
+        St. Pauli\",\"points\":\"0\",\"mp\":0,\"gp\":3},{\"roundId\":\"IZZCW7IG\",\"opponent\":\"FC
+        Bayern M\xFCnchen\",\"points\":\"0\",\"mp\":0,\"gp\":3.5},{\"roundId\":\"Woyg2kpP\",\"opponent\":\"SV
+        Deggendorf\",\"points\":\"0\",\"mp\":0,\"gp\":3.5},{\"roundId\":\"AlyVP7Tj\",\"opponent\":\"SK
+        Kirchweyhe\",\"points\":\"0\",\"mp\":0,\"gp\":3.5},{\"roundId\":\"SR1eddMe\",\"opponent\":\"SV
+        Werder Bremen\",\"points\":\"1\",\"mp\":1,\"gp\":5.5},{\"roundId\":\"nRVdmVdP\",\"opponent\":\"SF
+        Berlin\",\"points\":\"1\",\"mp\":1,\"gp\":4.5},{\"roundId\":\"2hgbLbso\",\"opponent\":\"USV
+        TU Dresden\",\"points\":\"0\",\"mp\":0,\"gp\":3}],\"players\":[{\"name\":\"Nasuta,
+        Grzegorz\",\"title\":\"GM\",\"rating\":2502,\"fideId\":1141686,\"team\":\"SC
+        Heimbach-Weis-Neuwied\",\"fed\":\"POL\",\"played\":6,\"score\":3.5},{\"name\":\"Kraemer,
+        Martin\",\"title\":\"GM\",\"rating\":2574,\"fideId\":4671910,\"team\":\"SC
+        Heimbach-Weis-Neuwied\",\"fed\":\"GER\",\"played\":8,\"score\":3.5},{\"name\":\"Zilka,
+        Stepan\",\"title\":\"GM\",\"rating\":2524,\"fideId\":315303,\"team\":\"SC
+        Heimbach-Weis-Neuwied\",\"fed\":\"CZE\",\"played\":4,\"score\":1.5},{\"name\":\"Lodici,
+        Lorenzo\",\"title\":\"GM\",\"rating\":2590,\"fideId\":884189,\"team\":\"SC
+        Heimbach-Weis-Neuwied\",\"fed\":\"ITA\",\"played\":2,\"score\":1},{\"name\":\"Roshka,
+        Yevgeniy\",\"title\":\"IM\",\"rating\":2503,\"fideId\":14129558,\"team\":\"SC
+        Heimbach-Weis-Neuwied\",\"fed\":\"UKR\",\"played\":6,\"score\":3.5},{\"name\":\"Livaic,
+        Leon\",\"title\":\"GM\",\"rating\":2554,\"fideId\":14531534,\"team\":\"SC
+        Heimbach-Weis-Neuwied\",\"fed\":\"CRO\",\"played\":8,\"score\":4.5},{\"name\":\"Kosakowski,
+        Jakub\",\"title\":\"GM\",\"rating\":2549,\"fideId\":1185080,\"team\":\"SC
+        Heimbach-Weis-Neuwied\",\"fed\":\"POL\",\"played\":6,\"score\":1.5},{\"name\":\"Neugebauer,
+        Martin\",\"title\":\"IM\",\"rating\":2505,\"fideId\":14923432,\"team\":\"SC
+        Heimbach-Weis-Neuwied\",\"fed\":\"SVK\",\"played\":6,\"score\":3.5},{\"name\":\"Tica,
+        Sven\",\"title\":\"IM\",\"rating\":2405,\"fideId\":14526948,\"team\":\"SC
+        Heimbach-Weis-Neuwied\",\"fed\":\"CRO\",\"played\":2,\"score\":0.5},{\"name\":\"Winterberg,
+        Lukas\",\"title\":\"IM\",\"rating\":2424,\"fideId\":24622702,\"team\":\"SC
+        Heimbach-Weis-Neuwied\",\"fed\":\"GER\",\"played\":8,\"score\":4},{\"name\":\"Ferreira,
+        Jorge Viterbo\",\"title\":\"GM\",\"rating\":2504,\"fideId\":1910850,\"team\":\"SC
+        Heimbach-Weis-Neuwied\",\"fed\":\"POR\",\"played\":6,\"score\":3},{\"name\":\"Ronge,
+        Tim\",\"title\":\"FM\",\"rating\":2284,\"fideId\":12955418,\"team\":\"SC Heimbach-Weis-Neuwied\",\"fed\":\"GER\",\"played\":2,\"score\":1}],\"averageRating\":2493},{\"name\":\"Schachfreunde
+        Deizisau\",\"mp\":3,\"gp\":29,\"matches\":[{\"roundId\":\"SY7G4X9F\",\"opponent\":\"SV
+        Werder Bremen\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"20EKKqrN\",\"opponent\":\"SK
+        Kirchweyhe\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"IZZCW7IG\",\"opponent\":\"Sfr.
+        Wolfhagen\",\"points\":\"1\",\"mp\":1,\"gp\":5},{\"roundId\":\"Woyg2kpP\",\"opponent\":\"SC
+        Viernheim\",\"points\":\"0\",\"mp\":0,\"gp\":2},{\"roundId\":\"AlyVP7Tj\",\"opponent\":\"SV
+        Deggendorf\",\"points\":\"1\",\"mp\":1,\"gp\":5},{\"roundId\":\"SR1eddMe\",\"opponent\":\"FC
+        Bayern M\xFCnchen\",\"points\":\"0\",\"mp\":0,\"gp\":2},{\"roundId\":\"nRVdmVdP\",\"opponent\":\"FC
+        St. Pauli\",\"points\":\"0\",\"mp\":0,\"gp\":3.5},{\"roundId\":\"2hgbLbso\",\"opponent\":\"Hamburger
+        SK\",\"points\":\"0\",\"mp\":0,\"gp\":3.5}],\"players\":[{\"name\":\"Krasenkow,
+        Michal\",\"title\":\"GM\",\"rating\":2475,\"fideId\":1113100,\"team\":\"Schachfreunde
+        Deizisau\",\"fed\":\"POL\",\"played\":2,\"score\":1.5},{\"name\":\"Bluebaum,
+        Matthias\",\"title\":\"GM\",\"rating\":2671,\"fideId\":24651516,\"team\":\"Schachfreunde
+        Deizisau\",\"fed\":\"GER\",\"played\":8,\"score\":4},{\"name\":\"Graf, Alexander\",\"title\":\"GM\",\"rating\":2500,\"fideId\":4680804,\"team\":\"Schachfreunde
+        Deizisau\",\"fed\":\"GER\",\"played\":6,\"score\":2.5},{\"name\":\"Kamsky,
+        Gata\",\"title\":\"GM\",\"rating\":2606,\"fideId\":2000024,\"team\":\"Schachfreunde
+        Deizisau\",\"fed\":\"FRA\",\"played\":6,\"score\":3.5},{\"name\":\"Movsesian,
+        Sergei\",\"title\":\"GM\",\"rating\":2604,\"fideId\":310204,\"team\":\"Schachfreunde
+        Deizisau\",\"fed\":\"ARM\",\"played\":2,\"score\":0.5},{\"name\":\"Banusz,
+        Tamas\",\"title\":\"GM\",\"rating\":2586,\"fideId\":722413,\"team\":\"Schachfreunde
+        Deizisau\",\"fed\":\"HUN\",\"played\":6,\"score\":4},{\"name\":\"Koellner,
+        Ruben Gideon\",\"title\":\"IM\",\"rating\":2515,\"fideId\":12993093,\"team\":\"Schachfreunde
+        Deizisau\",\"fed\":\"GER\",\"played\":2,\"score\":0.5},{\"name\":\"Kollars,
+        Dmitrij\",\"title\":\"GM\",\"rating\":2647,\"fideId\":12909572,\"team\":\"Schachfreunde
+        Deizisau\",\"fed\":\"GER\",\"played\":8,\"score\":3},{\"name\":\"Dardha, Daniel\",\"title\":\"GM\",\"rating\":2624,\"fideId\":240990,\"team\":\"Schachfreunde
+        Deizisau\",\"fed\":\"BEL\",\"played\":2,\"score\":1},{\"name\":\"Gledura,
+        Benjamin\",\"title\":\"GM\",\"rating\":2646,\"fideId\":712779,\"team\":\"Schachfreunde
+        Deizisau\",\"fed\":\"HUN\",\"played\":6,\"score\":2.5},{\"name\":\"Dautov,
+        Rustem\",\"title\":\"GM\",\"rating\":2552,\"fideId\":4623606,\"team\":\"Schachfreunde
+        Deizisau\",\"fed\":\"GER\",\"played\":8,\"score\":3},{\"name\":\"Kozak, Adam\",\"title\":\"GM\",\"rating\":2527,\"fideId\":753246,\"team\":\"Schachfreunde
+        Deizisau\",\"fed\":\"HUN\",\"played\":2,\"score\":1},{\"name\":\"Moussard,
+        Jules\",\"title\":\"GM\",\"rating\":2600,\"fideId\":642908,\"team\":\"Schachfreunde
+        Deizisau\",\"fed\":\"FRA\",\"played\":2,\"score\":0},{\"name\":\"Kozul, Zdenko\",\"title\":\"GM\",\"rating\":2500,\"fideId\":14502879,\"team\":\"Schachfreunde
+        Deizisau\",\"fed\":\"CRO\",\"played\":4,\"score\":2}],\"averageRating\":2575},{\"name\":\"D\xFCsseldorfer
+        SK\",\"mp\":3,\"gp\":28,\"matches\":[{\"roundId\":\"SY7G4X9F\",\"opponent\":\"SV
+        Deggendorf\",\"points\":\"1\",\"mp\":1,\"gp\":4.5},{\"roundId\":\"20EKKqrN\",\"opponent\":\"FC
+        Bayern M\xFCnchen\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"IZZCW7IG\",\"opponent\":\"SV
+        Werder Bremen\",\"points\":\"0\",\"mp\":0,\"gp\":2.5},{\"roundId\":\"Woyg2kpP\",\"opponent\":\"SK
+        Kirchweyhe\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"AlyVP7Tj\",\"opponent\":\"USV
+        TU Dresden\",\"points\":\"1\",\"mp\":1,\"gp\":5.5},{\"roundId\":\"SR1eddMe\",\"opponent\":\"SF
+        Berlin\",\"points\":\"0\",\"mp\":0,\"gp\":3},{\"roundId\":\"nRVdmVdP\",\"opponent\":\"Sfr.
+        Wolfhagen\",\"points\":\"0\",\"mp\":0,\"gp\":3},{\"roundId\":\"2hgbLbso\",\"opponent\":\"SC
+        Viernheim\",\"points\":\"0\",\"mp\":0,\"gp\":1.5}],\"players\":[{\"name\":\"Berelowitsch,
+        Alexander\",\"title\":\"GM\",\"rating\":2480,\"fideId\":14101440,\"team\":\"D\xFCsseldorfer
+        SK\",\"fed\":\"GER\",\"played\":2,\"score\":1},{\"name\":\"Pijpers, Arthur\",\"title\":\"GM\",\"rating\":2490,\"fideId\":1019554,\"team\":\"D\xFCsseldorfer
+        SK\",\"fed\":\"NED\",\"played\":6,\"score\":2.5},{\"name\":\"Kobalia, Mikhail\",\"title\":\"GM\",\"rating\":2531,\"fideId\":4119150,\"team\":\"D\xFCsseldorfer
+        SK\",\"fed\":\"FID\",\"played\":6,\"score\":2.5},{\"name\":\"Pavlidis, Antonios\",\"title\":\"GM\",\"rating\":2570,\"fideId\":4212312,\"team\":\"D\xFCsseldorfer
+        SK\",\"fed\":\"GRE\",\"played\":6,\"score\":3},{\"name\":\"Levin, Felix\",\"title\":\"GM\",\"rating\":2415,\"fideId\":4650905,\"team\":\"D\xFCsseldorfer
+        SK\",\"fed\":\"GER\",\"played\":6,\"score\":3},{\"name\":\"Swinkels, Robin\",\"title\":\"GM\",\"rating\":2481,\"fideId\":1010824,\"team\":\"D\xFCsseldorfer
+        SK\",\"fed\":\"NED\",\"played\":4,\"score\":1},{\"name\":\"Li, Hewei\",\"rating\":2151,\"fideId\":34619763,\"team\":\"D\xFCsseldorfer
+        SK\",\"fed\":\"GER\",\"played\":2,\"score\":0.5},{\"name\":\"Burg, Twan\",\"title\":\"GM\",\"rating\":2490,\"fideId\":1010697,\"team\":\"D\xFCsseldorfer
+        SK\",\"fed\":\"NED\",\"played\":2,\"score\":0.5},{\"name\":\"Klaska, Philipp
+        Leon\",\"title\":\"FM\",\"rating\":2306,\"fideId\":16238044,\"team\":\"D\xFCsseldorfer
+        SK\",\"fed\":\"GER\",\"played\":6,\"score\":2},{\"name\":\"Bologan, Victor\",\"title\":\"GM\",\"rating\":2601,\"fideId\":13900048,\"team\":\"D\xFCsseldorfer
+        SK\",\"fed\":\"MDA\",\"played\":2,\"score\":1},{\"name\":\"Haria, Ravi\",\"title\":\"GM\",\"rating\":2493,\"fideId\":415820,\"team\":\"D\xFCsseldorfer
+        SK\",\"fed\":\"ENG\",\"played\":2,\"score\":1},{\"name\":\"Murzin, Volodar\",\"title\":\"GM\",\"rating\":2670,\"fideId\":44155573,\"team\":\"D\xFCsseldorfer
+        SK\",\"fed\":\"FID\",\"played\":6,\"score\":3.5},{\"name\":\"Orlov, Andrey\",\"title\":\"GM\",\"rating\":2474,\"fideId\":4125282,\"team\":\"D\xFCsseldorfer
+        SK\",\"fed\":\"FID\",\"played\":8,\"score\":2.5},{\"name\":\"Schoppen, Casper\",\"title\":\"GM\",\"rating\":2552,\"fideId\":1046730,\"team\":\"D\xFCsseldorfer
+        SK\",\"fed\":\"NED\",\"played\":6,\"score\":4}],\"averageRating\":2479},{\"name\":\"SV
+        Deggendorf\",\"mp\":2.5,\"gp\":30.5,\"matches\":[{\"roundId\":\"SY7G4X9F\",\"opponent\":\"D\xFCsseldorfer
+        SK\",\"points\":\"0\",\"mp\":0,\"gp\":3.5},{\"roundId\":\"20EKKqrN\",\"opponent\":\"SG
+        Solingen\",\"points\":\"0\",\"mp\":0,\"gp\":3.5},{\"roundId\":\"IZZCW7IG\",\"opponent\":\"OSG
+        Baden-Baden\",\"points\":\"0\",\"mp\":0,\"gp\":3.5},{\"roundId\":\"Woyg2kpP\",\"opponent\":\"SC
+        Heimbach-Weis-Neuwied\",\"points\":\"1\",\"mp\":1,\"gp\":4.5},{\"roundId\":\"AlyVP7Tj\",\"opponent\":\"Schachfreunde
+        Deizisau\",\"points\":\"0\",\"mp\":0,\"gp\":3},{\"roundId\":\"SR1eddMe\",\"opponent\":\"MSA
+        Zugzwang\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"nRVdmVdP\",\"opponent\":\"SV
+        Werder Bremen\",\"points\":\"0\",\"mp\":0,\"gp\":3.5},{\"roundId\":\"2hgbLbso\",\"opponent\":\"SK
+        Kirchweyhe\",\"points\":\"1\",\"mp\":1,\"gp\":5}],\"players\":[{\"name\":\"Sedlak,
+        Nikola\",\"title\":\"GM\",\"rating\":2380,\"fideId\":922900,\"team\":\"SV
+        Deggendorf\",\"fed\":\"SRB\",\"played\":6,\"score\":2},{\"name\":\"Bogosavljevic,
+        Boban\",\"title\":\"GM\",\"rating\":2446,\"fideId\":931152,\"team\":\"SV Deggendorf\",\"fed\":\"SRB\",\"played\":8,\"score\":5},{\"name\":\"Karthik
+        Venkataraman\",\"title\":\"GM\",\"rating\":2589,\"fideId\":25006479,\"team\":\"SV
+        Deggendorf\",\"fed\":\"IND\",\"played\":2,\"score\":1.5},{\"name\":\"Erigaisi
+        Arjun\",\"title\":\"GM\",\"rating\":2775,\"fideId\":35009192,\"team\":\"SV
+        Deggendorf\",\"fed\":\"IND\",\"played\":2,\"score\":1.5},{\"name\":\"Ghosh,
+        Diptayan\",\"title\":\"GM\",\"rating\":2577,\"fideId\":5045207,\"team\":\"SV
+        Deggendorf\",\"fed\":\"IND\",\"played\":4,\"score\":3},{\"name\":\"Indjic,
+        Aleksandar\",\"title\":\"GM\",\"rating\":2635,\"fideId\":911925,\"team\":\"SV
+        Deggendorf\",\"fed\":\"SRB\",\"played\":2,\"score\":0},{\"name\":\"Narayanan
+        S L\",\"title\":\"GM\",\"rating\":2616,\"fideId\":5058422,\"team\":\"SV Deggendorf\",\"fed\":\"IND\",\"played\":4,\"score\":2.5},{\"name\":\"Delchev,
+        Aleksander\",\"title\":\"GM\",\"rating\":2406,\"fideId\":2900394,\"team\":\"SV
+        Deggendorf\",\"fed\":\"SRB\",\"played\":8,\"score\":4},{\"name\":\"Sankalp
+        Gupta\",\"title\":\"GM\",\"rating\":2559,\"fideId\":5097010,\"team\":\"SV
+        Deggendorf\",\"fed\":\"IND\",\"played\":2,\"score\":0.5},{\"name\":\"Petrov,
+        Martin\",\"title\":\"GM\",\"rating\":2533,\"fideId\":2911086,\"team\":\"SV
+        Deggendorf\",\"fed\":\"BUL\",\"played\":8,\"score\":2.5},{\"name\":\"Stojanovic,
+        Dalibor\",\"title\":\"GM\",\"rating\":2434,\"fideId\":922692,\"team\":\"SV
+        Deggendorf\",\"fed\":\"BIH\",\"played\":6,\"score\":3.5},{\"name\":\"Wisnet,
+        Dominic\",\"title\":\"FM\",\"rating\":2255,\"fideId\":24629200,\"team\":\"SV
+        Deggendorf\",\"fed\":\"GER\",\"played\":2,\"score\":0},{\"name\":\"Miljkovic,
+        Miroslav D\",\"title\":\"GM\",\"rating\":2404,\"fideId\":922722,\"team\":\"SV
+        Deggendorf\",\"fed\":\"SRB\",\"played\":2,\"score\":0.5},{\"name\":\"Dudin,
+        Gleb\",\"title\":\"GM\",\"rating\":2585,\"fideId\":34184934,\"team\":\"SV
+        Deggendorf\",\"fed\":\"HUN\",\"played\":2,\"score\":1},{\"name\":\"Krivoborodov,
+        Egor\",\"title\":\"GM\",\"rating\":2534,\"fideId\":4155890,\"team\":\"SV Deggendorf\",\"fed\":\"GER\",\"played\":6,\"score\":3}],\"averageRating\":2515},{\"name\":\"MSA
+        Zugzwang\",\"mp\":1.5,\"gp\":27,\"matches\":[{\"roundId\":\"SY7G4X9F\",\"opponent\":\"SK
+        Kirchweyhe\",\"points\":\"0\",\"mp\":0,\"gp\":3.5},{\"roundId\":\"20EKKqrN\",\"opponent\":\"SV
+        Werder Bremen\",\"points\":\"0\",\"mp\":0,\"gp\":3.5},{\"roundId\":\"IZZCW7IG\",\"opponent\":\"SC
+        Viernheim\",\"points\":\"0\",\"mp\":0,\"gp\":1.5},{\"roundId\":\"Woyg2kpP\",\"opponent\":\"Sfr.
+        Wolfhagen\",\"points\":\"0\",\"mp\":0,\"gp\":2.5},{\"roundId\":\"AlyVP7Tj\",\"opponent\":\"FC
+        Bayern M\xFCnchen\",\"points\":\"0\",\"mp\":0,\"gp\":3.5},{\"roundId\":\"SR1eddMe\",\"opponent\":\"SV
+        Deggendorf\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"nRVdmVdP\",\"opponent\":\"Hamburger
+        SK\",\"points\":\"0\",\"mp\":0,\"gp\":3.5},{\"roundId\":\"2hgbLbso\",\"opponent\":\"FC
+        St. Pauli\",\"points\":\"1\",\"mp\":1,\"gp\":5}],\"players\":[{\"name\":\"Bromberger,
+        Stefan\",\"title\":\"GM\",\"rating\":2489,\"fideId\":4635248,\"team\":\"MSA
+        Zugzwang\",\"fed\":\"GER\",\"played\":4,\"score\":1},{\"name\":\"Horvath,
+        Dominik\",\"title\":\"GM\",\"rating\":2557,\"fideId\":1642561,\"team\":\"MSA
+        Zugzwang\",\"fed\":\"AUT\",\"played\":6,\"score\":3},{\"name\":\"Kunin, Vitaly\",\"title\":\"GM\",\"rating\":2507,\"fideId\":4128737,\"team\":\"MSA
+        Zugzwang\",\"fed\":\"GER\",\"played\":8,\"score\":2.5},{\"name\":\"Costa,
+        Leonardo\",\"title\":\"GM\",\"rating\":2544,\"fideId\":16213955,\"team\":\"MSA
+        Zugzwang\",\"fed\":\"GER\",\"played\":8,\"score\":3},{\"name\":\"Shengelia,
+        David\",\"title\":\"GM\",\"rating\":2480,\"fideId\":13601270,\"team\":\"MSA
+        Zugzwang\",\"fed\":\"AUT\",\"played\":6,\"score\":2.5},{\"name\":\"Hertneck,
+        Gerald\",\"title\":\"GM\",\"rating\":2420,\"fideId\":4600088,\"team\":\"MSA
+        Zugzwang\",\"fed\":\"GER\",\"played\":7,\"score\":4.5},{\"name\":\"Gerigk,
+        Erasmus\",\"title\":\"FM\",\"rating\":2286,\"fideId\":4614119,\"team\":\"MSA
+        Zugzwang\",\"fed\":\"GER\",\"played\":1,\"score\":0.5},{\"name\":\"Eljanov,
+        Pavel\",\"title\":\"GM\",\"rating\":2682,\"fideId\":14102951,\"team\":\"MSA
+        Zugzwang\",\"fed\":\"UKR\",\"played\":6,\"score\":4.5},{\"name\":\"Zysk, Robert\",\"title\":\"IM\",\"rating\":2375,\"fideId\":4600410,\"team\":\"MSA
+        Zugzwang\",\"fed\":\"GER\",\"played\":2,\"score\":0},{\"name\":\"Zeller, Frank\",\"title\":\"IM\",\"rating\":2319,\"fideId\":4613007,\"team\":\"MSA
+        Zugzwang\",\"fed\":\"GER\",\"played\":2,\"score\":0.5},{\"name\":\"Kjartansson,
+        Gudmundur\",\"title\":\"GM\",\"rating\":2420,\"fideId\":2301318,\"team\":\"MSA
+        Zugzwang\",\"fed\":\"ISL\",\"played\":4,\"score\":1},{\"name\":\"Baidetskyi,
+        Valentin\",\"title\":\"IM\",\"rating\":2483,\"fideId\":14142317,\"team\":\"MSA
+        Zugzwang\",\"fed\":\"AUT\",\"played\":6,\"score\":2.5},{\"name\":\"Kindermann,
+        Stefan\",\"title\":\"GM\",\"rating\":2449,\"fideId\":4600053,\"team\":\"MSA
+        Zugzwang\",\"fed\":\"AUT\",\"played\":4,\"score\":1.5}],\"averageRating\":2462},{\"name\":\"SF
+        Berlin\",\"mp\":1.5,\"gp\":24.5,\"matches\":[{\"roundId\":\"SY7G4X9F\",\"opponent\":\"SC
+        Viernheim\",\"points\":\"0\",\"mp\":0,\"gp\":2.5},{\"roundId\":\"20EKKqrN\",\"opponent\":\"Sfr.
+        Wolfhagen\",\"points\":\"0\",\"mp\":0,\"gp\":2},{\"roundId\":\"IZZCW7IG\",\"opponent\":\"Hamburger
+        SK\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"Woyg2kpP\",\"opponent\":\"FC
+        St. Pauli\",\"points\":\"0\",\"mp\":0,\"gp\":3.5},{\"roundId\":\"AlyVP7Tj\",\"opponent\":\"SG
+        Solingen\",\"points\":\"0\",\"mp\":0,\"gp\":3},{\"roundId\":\"SR1eddMe\",\"opponent\":\"D\xFCsseldorfer
+        SK\",\"points\":\"1\",\"mp\":1,\"gp\":5},{\"roundId\":\"nRVdmVdP\",\"opponent\":\"SC
+        Heimbach-Weis-Neuwied\",\"points\":\"0\",\"mp\":0,\"gp\":3.5},{\"roundId\":\"2hgbLbso\",\"opponent\":\"OSG
+        Baden-Baden\",\"points\":\"0\",\"mp\":0,\"gp\":1}],\"players\":[{\"name\":\"Moranda,
+        Wojciech\",\"title\":\"GM\",\"rating\":2541,\"fideId\":1122401,\"team\":\"SF
+        Berlin\",\"fed\":\"POL\",\"played\":2,\"score\":1},{\"name\":\"Tomczak, Jacek\",\"title\":\"GM\",\"rating\":2537,\"fideId\":1124668,\"team\":\"SF
+        Berlin\",\"fed\":\"POL\",\"played\":4,\"score\":1.5},{\"name\":\"Schmidek,
+        Emil\",\"title\":\"IM\",\"rating\":2432,\"fideId\":12908150,\"team\":\"SF
+        Berlin\",\"fed\":\"GER\",\"played\":4,\"score\":0.5},{\"name\":\"Ermitsch,
+        Magnus\",\"title\":\"IM\",\"rating\":2414,\"fideId\":16234464,\"team\":\"SF
+        Berlin\",\"fed\":\"GER\",\"played\":8,\"score\":3.5},{\"name\":\"Dotzer, Lukas\",\"title\":\"IM\",\"rating\":2468,\"fideId\":1666975,\"team\":\"SF
+        Berlin\",\"fed\":\"AUT\",\"played\":4,\"score\":1},{\"name\":\"Lagunow, Raphael\",\"title\":\"IM\",\"rating\":2433,\"fideId\":24652644,\"team\":\"SF
+        Berlin\",\"fed\":\"GER\",\"played\":7,\"score\":2},{\"name\":\"Schneider,
+        Ilja\",\"title\":\"IM\",\"rating\":2417,\"fideId\":4663306,\"team\":\"SF Berlin\",\"fed\":\"GER\",\"played\":5,\"score\":2.5},{\"name\":\"Neiksans,
+        Arturs\",\"title\":\"GM\",\"rating\":2582,\"fideId\":11601388,\"team\":\"SF
+        Berlin\",\"fed\":\"LAT\",\"played\":4,\"score\":1.5},{\"name\":\"Sawlin, Leonid\",\"title\":\"IM\",\"rating\":2400,\"fideId\":4689542,\"team\":\"SF
+        Berlin\",\"fed\":\"GER\",\"played\":2,\"score\":1},{\"name\":\"Baum, Jonasz\",\"title\":\"IM\",\"rating\":2446,\"fideId\":1195360,\"team\":\"SF
+        Berlin\",\"fed\":\"POL\",\"played\":6,\"score\":3.5},{\"name\":\"Klimkowski,
+        Jan\",\"title\":\"GM\",\"rating\":2520,\"fideId\":21856222,\"team\":\"SF Berlin\",\"fed\":\"POL\",\"played\":8,\"score\":3},{\"name\":\"Vavulin,
+        Maxim\",\"title\":\"GM\",\"rating\":2545,\"fideId\":4169530,\"team\":\"SF
+        Berlin\",\"fed\":\"GER\",\"played\":4,\"score\":0.5},{\"name\":\"Fromm, Marius\",\"title\":\"IM\",\"rating\":2406,\"fideId\":12993190,\"team\":\"SF
+        Berlin\",\"fed\":\"GER\",\"played\":6,\"score\":3}],\"averageRating\":2472},{\"name\":\"USV
+        TU Dresden\",\"mp\":1.5,\"gp\":22,\"matches\":[{\"roundId\":\"SY7G4X9F\",\"opponent\":\"Sfr.
+        Wolfhagen\",\"points\":\"0\",\"mp\":0,\"gp\":2.5},{\"roundId\":\"20EKKqrN\",\"opponent\":\"SC
+        Viernheim\",\"points\":\"0\",\"mp\":0,\"gp\":2},{\"roundId\":\"IZZCW7IG\",\"opponent\":\"FC
+        St. Pauli\",\"points\":\"1/2\",\"mp\":0.5,\"gp\":4},{\"roundId\":\"Woyg2kpP\",\"opponent\":\"Hamburger
+        SK\",\"points\":\"0\",\"mp\":0,\"gp\":3},{\"roundId\":\"AlyVP7Tj\",\"opponent\":\"D\xFCsseldorfer
+        SK\",\"points\":\"0\",\"mp\":0,\"gp\":2.5},{\"roundId\":\"SR1eddMe\",\"opponent\":\"SG
+        Solingen\",\"points\":\"0\",\"mp\":0,\"gp\":1.5},{\"roundId\":\"nRVdmVdP\",\"opponent\":\"OSG
+        Baden-Baden\",\"points\":\"0\",\"mp\":0,\"gp\":1.5},{\"roundId\":\"2hgbLbso\",\"opponent\":\"SC
+        Heimbach-Weis-Neuwied\",\"points\":\"1\",\"mp\":1,\"gp\":5}],\"players\":[{\"name\":\"Nisipeanu,
+        Liviu-Dieter\",\"title\":\"GM\",\"rating\":2580,\"fideId\":1202758,\"team\":\"USV
+        TU Dresden\",\"fed\":\"ROU\",\"played\":4,\"score\":2.5},{\"name\":\"Moehn,
+        Hans\",\"title\":\"FM\",\"rating\":2370,\"fideId\":24647837,\"team\":\"USV
+        TU Dresden\",\"fed\":\"GER\",\"played\":5,\"score\":1},{\"name\":\"Lutz, Ruben\",\"title\":\"FM\",\"rating\":2305,\"fideId\":12975974,\"team\":\"USV
+        TU Dresden\",\"fed\":\"GER\",\"played\":2,\"score\":0.5},{\"name\":\"Boensch,
+        Uwe\",\"title\":\"GM\",\"rating\":2456,\"fideId\":4611268,\"team\":\"USV TU
+        Dresden\",\"fed\":\"GER\",\"played\":6,\"score\":2},{\"name\":\"Tischbierek,
+        Raj\",\"title\":\"GM\",\"rating\":2412,\"fideId\":4611322,\"team\":\"USV TU
+        Dresden\",\"fed\":\"GER\",\"played\":2,\"score\":0.5},{\"name\":\"Nguyen,
+        Thai Dai Van\",\"title\":\"GM\",\"rating\":2660,\"fideId\":358878,\"team\":\"USV
+        TU Dresden\",\"fed\":\"CZE\",\"played\":2,\"score\":1.5},{\"name\":\"Hoffmann,
+        Paul\",\"title\":\"IM\",\"rating\":2366,\"fideId\":4664450,\"team\":\"USV
+        TU Dresden\",\"fed\":\"GER\",\"played\":3,\"score\":0.5},{\"name\":\"Druska,
+        Juraj\",\"title\":\"IM\",\"rating\":2457,\"fideId\":14915650,\"team\":\"USV
+        TU Dresden\",\"fed\":\"SVK\",\"played\":6,\"score\":2},{\"name\":\"Michalik,
+        Peter\",\"title\":\"GM\",\"rating\":2562,\"fideId\":14907526,\"team\":\"USV
+        TU Dresden\",\"fed\":\"SVK\",\"played\":6,\"score\":2},{\"name\":\"Vogel,
+        Roven\",\"title\":\"GM\",\"rating\":2534,\"fideId\":12908088,\"team\":\"USV
+        TU Dresden\",\"fed\":\"GER\",\"played\":6,\"score\":2.5},{\"name\":\"Maiwald,
+        Jens-Uwe\",\"title\":\"GM\",\"rating\":2412,\"fideId\":4612396,\"team\":\"USV
+        TU Dresden\",\"fed\":\"GER\",\"played\":2,\"score\":1},{\"name\":\"Fruth,
+        David\",\"rating\":2201,\"fideId\":16257596,\"team\":\"USV TU Dresden\",\"fed\":\"GER\",\"played\":2,\"score\":0},{\"name\":\"Pechac,
+        Jergus\",\"title\":\"GM\",\"rating\":2542,\"fideId\":14926970,\"team\":\"USV
+        TU Dresden\",\"fed\":\"SVK\",\"played\":2,\"score\":1},{\"name\":\"Bartel,
+        Mateusz\",\"title\":\"GM\",\"rating\":2581,\"fideId\":1112635,\"team\":\"USV
+        TU Dresden\",\"fed\":\"POL\",\"played\":8,\"score\":2.5},{\"name\":\"Neef,
+        Maximilian\",\"title\":\"IM\",\"rating\":2466,\"fideId\":24692085,\"team\":\"USV
+        TU Dresden\",\"fed\":\"GER\",\"played\":8,\"score\":2.5}],\"averageRating\":2460}]"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 24 Feb 2026 23:12:59 GMT
+      Permissions-Policy:
+      - screen-wake-lock=(self "https://lichess1.org"), microphone=(self), fullscreen=(self)
+      - interest-cohort=()
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '40632'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/clients/test_broadcasts.py
+++ b/tests/clients/test_broadcasts.py
@@ -1,7 +1,14 @@
 import pytest
 
+from typing import List
+
 from berserk import Client
-from berserk.types import BroadcastTop, PaginatedBroadcasts, BroadcastsByUser
+from berserk.types import (
+    BroadcastTeamStandingsItem,
+    BroadcastTop,
+    PaginatedBroadcasts,
+    BroadcastsByUser,
+)
 from utils import skip_if_older_3_dot_10, validate
 
 
@@ -23,3 +30,21 @@ class TestBroadcasts:
     def test_get_by_user(self):
         res = Client().broadcasts.get_by_user(username="lichess", page=1)
         validate(BroadcastsByUser, res)
+
+    @skip_if_older_3_dot_10
+    @pytest.mark.vcr
+    def test_get_team_standings(self):
+        """Get team leaderboard for a broadcast.
+
+        A broadcast is a Lichess relay of an external chess event (OTB/online);
+        it has a tour (tournament) and rounds with games. Standings exist when
+        the tour is a team event (tour.teamTable is true) and teams are assigned
+        (e.g. via WhiteTeam/BlackTeam in PGN or manual assignment). To find
+        broadcasts with non-empty standings: get_top() or search(), filter for
+        tour.teamTable, then call get_team_standings(tour.id) until len > 0.
+        This test uses a broadcast that has team standings (e.g. German
+        Bundesliga). Re-record if it later returns [] (delete cassette, make
+        test_record, or pick another tour.id from get_top with teamTable).
+        """
+        res = Client().broadcasts.get_team_standings("Y9YjcDKG")
+        validate(List[BroadcastTeamStandingsItem], res)


### PR DESCRIPTION
Part of #6.

Adds `client.broadcasts.get_team_standings(broadcast_tournament_id)` for GET `/broadcast/{id}/teams/standings`, returning the team leaderboard of a broadcast. TypedDicts in `berserk/types/broadcast.py` (BroadcastTeamStandingsItem, etc.), VCR test with non-empty response, README.rst and CHANGELOG.rst updated.

## Checklist when adding a new endpoint

- [x] Added new endpoint to the `README.rst`
- [x] Ensured that my endpoint name does not repeat the name of the client. Wrong: `client.users.get_user()`, Correct: `client.users.get()`
- [x] Typed the returned JSON using TypedDicts in `berserk/types/`, [example](https://github.com/lichess-org/berserk/blob/master/berserk/types/team.py#L32)
- [x] Written tests for GET endpoints not requiring authentification. [Documentation](https://github.com/lichess-org/berserk/blob/master/CONTRIBUTING.rst#using-pytest-recording--vcrpy), [example](https://github.com/lichess-org/berserk/blob/master/tests/clients/test_teams.py#L11)
- [x] Added the endpoint and your name to `CHANGELOG.rst` in the `To be released` section (to be created if necessary)
