### PR TITLE
#6 Add studies.update_chapter_tags

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 To be released
 --------------
 
+* Added ``client.studies.update_chapter_tags`` to update PGN tags of a study chapter.
 
 * Deprecate Python 3.9 support - minimum required version is now Python 3.10+. This does not mean the library will not work with Python 3.9, but it will not be tested against it anymore.
 

--- a/README.rst
+++ b/README.rst
@@ -192,6 +192,7 @@ Most of the API is available:
     client.studies.export
     client.studies.export_by_username
     client.studies.import_pgn
+    client.studies.update_chapter_tags
 
     client.tablebase.look_up
     client.tablebase.standard

--- a/berserk/clients/studies.py
+++ b/berserk/clients/studies.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import cast, List, Iterator, Dict, Any
+from typing import Any, Dict, Iterator, List, cast
 
-from ..formats import PGN, NDJSON
+from ..formats import NDJSON, PGN
 from ..types.common import Color, VariantKey
 from ..types import ChapterIdName
 from .base import BaseClient
@@ -132,6 +132,20 @@ class Studies(BaseClient):
         return cast(
             List[ChapterIdName], self._r.post(path, data=payload).get("chapters", [])
         )
+
+    def update_chapter_tags(self, study_id: str, chapter_id: str, pgn: str) -> None:
+        """Update PGN tags of a study chapter.
+
+        Add, update, or delete PGN tags by providing PGN text (only the tag
+        lines are used; moves are ignored). Omitted tags are left unchanged.
+
+        :param study_id: study id (8 characters)
+        :param chapter_id: chapter id (8 characters)
+        :param pgn: PGN text containing the tags to set
+        :return: None (API returns 204 No Content on success)
+        """
+        path = f"/api/study/{study_id}/{chapter_id}/tags"
+        self._r.post(path, data={"pgn": pgn})
 
     def get_by_user(self, username: str) -> Iterator[Dict[str, Any]]:
         """

--- a/berserk/session.py
+++ b/berserk/session.py
@@ -99,6 +99,9 @@ class Requestor(Generic[T]):
         if not response.ok:
             raise exceptions.ResponseError(response)
 
+        if response.status_code == 204:
+            return None
+
         return fmt.handle(response, is_stream=stream, converter=converter)
 
     @overload

--- a/tests/clients/test_studies.py
+++ b/tests/clients/test_studies.py
@@ -1,0 +1,27 @@
+import requests_mock
+
+from berserk import Client
+
+
+class TestUpdateChapterTags:
+    def test_request_path_and_form_body(self):
+        """Request hits correct path and sends form-encoded pgn body (204)."""
+        pgn = '[Event "Test"]\n[Site "Lichess"]'
+        with requests_mock.Mocker() as m:
+            m.post(
+                "https://lichess.org/api/study/abc123/chapter456/tags",
+                status_code=204,
+            )
+            res = Client().studies.update_chapter_tags("abc123", "chapter456", pgn=pgn)
+            assert res is None
+            assert m.called
+            assert m.call_count == 1
+            assert m.last_request.method == "POST"
+            assert (
+                m.last_request.headers["Content-Type"]
+                == "application/x-www-form-urlencoded"
+            )
+            assert (
+                m.last_request.body
+                == "pgn=%5BEvent+%22Test%22%5D%0A%5BSite+%22Lichess%22%5D"
+            )


### PR DESCRIPTION
Part of #6.

Adds `client.studies.update_chapter_tags(study_id, chapter_id, pgn)` for the Lichess study chapter tags endpoint (POST, form-encoded body, 204 No Content). Session handles 204 by returning `None`. Requests-mock test for path and form body.

<details>
<summary>Checklist when adding a new endpoint</summary>

- [x] Added new endpoint to the README.rst
- [x] Ensured that my endpoint name does not repeat the name of the client. Wrong: `client.users.get_user()`, Correct: `client.users.get()`
- [x] Typed the returned JSON using TypedDicts in `berserk/types/` — N/A (endpoint returns 204 No Content, no response body)
- [x] Written tests for GET endpoints not requiring authentification — N/A (POST endpoint; added requests-mock test for request path and body)
- [x] Added the endpoint and your name to CHANGELOG.rst in the `To be released` section
</details>
