### PR TITLE
#6 Add Tournaments.get_played

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 To be released
 --------------
 
+* Added ``client.tournaments.get_played`` (tournaments played by user).
 
 * Deprecate Python 3.9 support - minimum required version is now Python 3.10+. This does not mean the library will not work with Python 3.9, but it will not be tested against it anymore.
 

--- a/README.rst
+++ b/README.rst
@@ -215,6 +215,7 @@ Most of the API is available:
     client.tournaments.get
     client.tournaments.get_tournament
     client.tournaments.get_swiss
+    client.tournaments.get_played
     client.tournaments.get_team_standings
     client.tournaments.update_team_battle
     client.tournaments.create_arena

--- a/berserk/clients/tournaments.py
+++ b/berserk/clients/tournaments.py
@@ -5,7 +5,13 @@ from typing import Iterator, Any, Dict, List, cast
 from .. import models
 from ..formats import NDJSON, NDJSON_LIST, PGN, TEXT
 from .base import FmtClient
-from ..types import ArenaResult, CurrentTournaments, SwissInfo, SwissResult
+from ..types import (
+    ArenaResult,
+    ArenaTournamentPlayed,
+    CurrentTournaments,
+    SwissInfo,
+    SwissResult,
+)
 from ..types.tournaments import TeamBattleResult
 
 
@@ -58,6 +64,29 @@ class Tournaments(FmtClient):
             "pairMeAsap": should_pair_immediately,
         }
         self._r.post(path=path, params=params, converter=models.Tournament.convert)
+
+    def get_played(
+        self,
+        username: str,
+        nb: int | None = None,
+        performance: bool | None = None,
+    ) -> List[ArenaTournamentPlayed]:
+        """Get tournaments played by a user.
+
+        Tournaments are sorted by reverse chronological order of start date
+        (last played first). Response is throttled depending on authentication.
+
+        :param username: the user whose played tournaments to fetch
+        :param nb: max number of tournaments to fetch
+        :param performance: include the player performance rating in the response
+        :return: list of tournament entries with player stats
+        """
+        path = f"/api/user/{username}/tournament/played"
+        params = {"nb": nb, "performance": performance}
+        return cast(
+            List[ArenaTournamentPlayed],
+            self._r.get(path, params=params, fmt=NDJSON_LIST),
+        )
 
     def get_team_standings(self, tournament_id: str) -> TeamBattleResult:
         """Get team standing of a team battle tournament, with their respective top players.

--- a/berserk/types/__init__.py
+++ b/berserk/types/__init__.py
@@ -29,12 +29,21 @@ from .opening_explorer import (
 )
 from .studies import ChapterIdName
 from .team import PaginatedTeams, Team
-from .tournaments import ArenaResult, CurrentTournaments, SwissResult, SwissInfo
+from .tournaments import (
+    ArenaResult,
+    ArenaTournamentPlayed,
+    ArenaTournamentPlayer,
+    CurrentTournaments,
+    SwissInfo,
+    SwissResult,
+)
 from .tv import TVFeed
 
 __all__ = [
     "AccountInformation",
     "ArenaResult",
+    "ArenaTournamentPlayed",
+    "ArenaTournamentPlayer",
     "BroadcastPlayer",
     "BroadcastsByUser",
     "BroadcastTop",

--- a/berserk/types/tournaments.py
+++ b/berserk/types/tournaments.py
@@ -81,3 +81,19 @@ class TeamResult(TypedDict):
 class TeamBattleResult(TypedDict):
     id: str
     teams: List[TeamResult]
+
+
+class ArenaTournamentPlayer(TypedDict):
+    """Player stats for a tournament played by a user (GET /api/user/{username}/tournament/played)."""
+
+    games: int
+    score: int
+    rank: int
+    performance: NotRequired[int]
+
+
+class ArenaTournamentPlayed(TypedDict):
+    """Tournament plus player stats (GET /api/user/{username}/tournament/played)."""
+
+    tournament: Dict[str, Any]
+    player: ArenaTournamentPlayer

--- a/tests/clients/cassettes/test_tournaments/TestLichessGames.test_get_played.yaml
+++ b/tests/clients/cassettes/test_tournaments/TestLichessGames.test_get_played.yaml
@@ -1,0 +1,55 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/x-ndjson
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.5
+    method: GET
+    uri: https://lichess.org/api/user/thibault/tournament/played?nb=3
+  response:
+    body:
+      string: '{"tournament":{"id":"TqYKG7b3","createdBy":"blakedoyle","system":"arena","minutes":720,"clock":{"limit":120,"increment":2},"rated":true,"fullName":"Antichess
+        lovers RANDOM Team Battle","nbPlayers":101,"variant":{"key":"antichess","short":"Anti","name":"Antichess"},"startsAt":1771937590606,"finishesAt":1771980790606,"status":30,"perf":{"key":"antichess","name":"Antichess","position":9},"teamBattle":{"teams":["lichess-racing-kings","darkonblitz-dob","bengal-tiger","lichess-chess960","gkr_gabriel--friends","dark-knights-chez-club","--elite-chess-players-union--","world-antichess-front","atomic-titans","world-chess-hunters","fide-checkmate-coronavirus","antichessmasters-ii","world-racing-kings-front","darkonbot","antichess-russia","darkonteams","100-zerk-rate","world-king-of-the-hill-front","lichess-king-of-the-hill","antichess-usa","atomic-addiction","lichess-antichess","lichess-en-espanol","kidch3ss-fan-club","atomic-chess-theoreticians","vegan-players","lichess-crazyhouse","world-chess-front-official","bharat-royals","antichess-960","darkknights-chess-academy-mumbai","crestbook-chess-club","antichess","antichess-titles","moon-club","world-atomic-front","aceidfs-fan-team","darkonswiss-dos","SKMom8QG","atomic960-tournament","anits-online-chess","atomic-for-fun","antichess-academy","darkonrapid","russian-chess-players","antichess-legends","dark-horse","lichess-horde","atomic-wc","antichess-league-team-battle","lichess-atomic","atomic-academy","world-chess-learner","atomic-dinosaurs","zhigalko_sergei-fan-club","ewie-fan-club","the-royal-empire","lichess-three-check","darkonclassical","the-house-discord-server","antichess-wc","antichessmasters","dark-pawn-go-for-win","wwwantichessorg"],"nbLeaders":7}},"player":{"games":1,"score":0,"rank":91}}
+
+        {"tournament":{"id":"YTlkQ9Ff","createdBy":"lichess","system":"arena","minutes":120,"clock":{"limit":300,"increment":0},"rated":true,"fullName":"Eastern
+        Blitz Arena","nbPlayers":1203,"variant":{"key":"standard","short":"Std","name":"Standard"},"startsAt":1771221600000,"finishesAt":1771228800000,"status":30,"perf":{"key":"blitz","name":"Blitz","position":1,"icon":")"},"minRatedGames":{"nb":15},"schedule":{"freq":"eastern","speed":"blitz"}},"player":{"games":1,"score":0,"rank":1130}}
+
+        {"tournament":{"id":"XGTv7hEK","createdBy":"thibault","system":"arena","minutes":480,"clock":{"limit":180,"increment":0},"rated":true,"fullName":"thibault
+        Arena","nbPlayers":2,"variant":{"key":"standard","short":"Std","name":"Standard"},"startsAt":1769677070691,"finishesAt":1769705870691,"status":30,"perf":{"key":"blitz","name":"Blitz","position":1,"icon":")"}},"player":{"games":1,"score":2,"rank":1}}
+
+        '
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Authorization, If-Modified-Since, Cache-Control, Content-Type
+      Access-Control-Allow-Methods:
+      - OPTIONS, GET, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/x-ndjson
+      Date:
+      - Wed, 25 Feb 2026 20:50:10 GMT
+      Permissions-Policy:
+      - interest-cohort=()
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/clients/test_tournaments.py
+++ b/tests/clients/test_tournaments.py
@@ -1,10 +1,11 @@
 import pytest
-
-from berserk import ArenaResult, Client, SwissResult
+import requests_mock
 from typing import List
 
+from berserk import ArenaResult, Client, SwissResult
+from berserk.types import ArenaTournamentPlayed
 from berserk.types.tournaments import TeamBattleResult
-from utils import validate, skip_if_older_3_dot_10
+from utils import skip_if_older_3_dot_10, validate
 
 
 class TestLichessGames:
@@ -31,3 +32,18 @@ class TestLichessGames:
     def test_team_standings(self):
         res = Client().tournaments.get_team_standings("Qv0dRqml")
         validate(TeamBattleResult, res)
+
+    @skip_if_older_3_dot_10
+    @pytest.mark.vcr
+    def test_get_played(self):
+        res = Client().tournaments.get_played("thibault", nb=3)
+        validate(List[ArenaTournamentPlayed], res)
+
+    def test_get_played_params(self):
+        """Verify that nb and performance query params are passed correctly."""
+        with requests_mock.Mocker() as m:
+            m.get(
+                "https://lichess.org/api/user/foo/tournament/played?nb=5&performance=true",
+                content=b"",
+            )
+            Client().tournaments.get_played("foo", nb=5, performance=True)


### PR DESCRIPTION
Part of #6.

Adds GET `/api/user/{username}/tournament/played`: `client.tournaments.get_played(username, nb=..., performance=...)` returning a list of tournaments played by the user with player stats. Typed with `ArenaTournamentPlayed` / `ArenaTournamentPlayer`; VCR test plus requests-mock test for query params.

**Checklist when adding a new endpoint**

- [x] Added new endpoint to the `README.rst`
- [x] Ensured that my endpoint name does not repeat the name of the client. Wrong: `client.users.get_user()`, Correct: `client.users.get()`
- [x] Typed the returned JSON using TypedDicts in `berserk/types/`, [example](https://github.com/lichess-org/berserk/blob/master/berserk/types/team.py#L32)
- [x] Written tests for GET endpoints not requiring authentification. [Documentation](https://github.com/lichess-org/berserk/blob/master/CONTRIBUTING.rst#using-pytest-recording--vcrpy), [example](https://github.com/lichess-org/berserk/blob/master/tests/clients/test_teams.py#L11)
- [x] Added the endpoint and your name to `CHANGELOG.rst` in the `To be released` section (to be created if necessary)
