### PR TITLE
#6 Add OAuth authorization_url

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 To be released
 --------------
 
+* Added ``client.oauth.authorization_url`` to build the OAuth2 authorization URL (GET /oauth) for the Authorization Code flow with PKCE.
 
 * Deprecate Python 3.9 support - minimum required version is now Python 3.10+. This does not mean the library will not work with Python 3.9, but it will not be tested against it anymore.
 

--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,7 @@ Most of the API is available:
 
     client.messaging.send
 
+    client.oauth.authorization_url
     client.oauth.test_tokens
 
     client.puzzles.get_daily

--- a/berserk/clients/oauth.py
+++ b/berserk/clients/oauth.py
@@ -14,7 +14,6 @@ class OAuth(BaseClient):
         client_id: str,
         redirect_uri: str,
         code_challenge: str,
-        *,
         state: str | None = None,
         scope: str | None = None,
         username: str | None = None,

--- a/berserk/clients/oauth.py
+++ b/berserk/clients/oauth.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from urllib.parse import urlencode, urljoin
+
 from typing import Any, Dict
 
 from .. import models
@@ -7,6 +9,48 @@ from .base import BaseClient
 
 
 class OAuth(BaseClient):
+    def authorization_url(
+        self,
+        client_id: str,
+        redirect_uri: str,
+        code_challenge: str,
+        *,
+        state: str | None = None,
+        scope: str | None = None,
+        username: str | None = None,
+    ) -> str:
+        """Build the OAuth2 authorization URL (GET /oauth) for the Authorization Code flow with PKCE.
+
+        Redirect the user to the returned URL to start the flow. After they authorize,
+        Lichess redirects to ``redirect_uri`` with a ``code`` and ``state`` in the query string.
+        Exchange the code for an access token via the token endpoint.
+
+        :param client_id: Arbitrary identifier that uniquely identifies your application.
+        :param redirect_uri: Absolute URL Lichess will redirect to with the authorization result.
+        :param code_challenge: BASE64URL(SHA256(code_verifier)). Keep code_verifier secret until token exchange.
+        :param state: Optional state echoed back on redirect; use for CSRF protection.
+        :param scope: Optional space-separated list of requested OAuth scopes.
+        :param username: Optional hint for the user to log in with a specific Lichess username.
+        :return: Full URL to send the user to for authorization.
+        """
+        params: Dict[str, str] = {
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "code_challenge_method": "S256",
+            "code_challenge": code_challenge,
+        }
+        if state is not None:
+            params["state"] = state
+        if scope is not None:
+            params["scope"] = scope
+        if username is not None:
+            params["username"] = username
+        path = "/oauth"
+        return urljoin(
+            self._r.base_url.rstrip("/") + "/", path + "?" + urlencode(params)
+        )
+
     def test_tokens(self, *tokens: str) -> Dict[str, Any]:
         """Test the validity of up to 1000 OAuth tokens.
 

--- a/tests/clients/test_oauth.py
+++ b/tests/clients/test_oauth.py
@@ -1,0 +1,50 @@
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from berserk import Client
+
+
+class TestOAuthAuthorizationUrl:
+    def test_authorization_url_contains_required_params(self):
+        """Required query params are present in the built URL."""
+        url = Client().oauth.authorization_url(
+            client_id="my-app",
+            redirect_uri="https://example.com/callback",
+            code_challenge="challenge123",
+        )
+        parsed = urlparse(url)
+        assert parsed.path.rstrip("/").endswith("/oauth")
+        qs = parse_qs(parsed.query)
+        assert qs["response_type"] == ["code"]
+        assert qs["client_id"] == ["my-app"]
+        assert qs["redirect_uri"] == ["https://example.com/callback"]
+        assert qs["code_challenge_method"] == ["S256"]
+        assert qs["code_challenge"] == ["challenge123"]
+
+    def test_authorization_url_optional_params(self):
+        """Optional state, scope, and username appear when provided."""
+        url = Client().oauth.authorization_url(
+            client_id="my-app",
+            redirect_uri="https://example.com/cb",
+            code_challenge="c",
+            state="xyz",
+            scope="email:read preference:read",
+            username="myuser",
+        )
+        qs = parse_qs(urlparse(url).query)
+        assert qs["state"] == ["xyz"]
+        assert qs["scope"] == ["email:read preference:read"]
+        assert qs["username"] == ["myuser"]
+
+    def test_authorization_url_omits_optional_params_when_none(self):
+        """Optional params are omitted when not passed."""
+        url = Client().oauth.authorization_url(
+            client_id="a",
+            redirect_uri="https://e.com/cb",
+            code_challenge="x",
+        )
+        qs = parse_qs(urlparse(url).query)
+        assert "state" not in qs
+        assert "scope" not in qs
+        assert "username" not in qs


### PR DESCRIPTION
Part of #6.

Adds `client.oauth.authorization_url()` to build the OAuth2 authorization URL (GET /oauth) for the Authorization Code flow with PKCE. Callers redirect the user to the returned URL; no HTTP request is made by the client. Optional params: state, scope, username. Unit tests assert the built URL contains the correct query params (no requests-mock: method does not perform a request).

<details>
<summary>Checklist when adding a new endpoint</summary>

- [x] Added new endpoint to the `README.rst`
- [x] Ensured that my endpoint name does not repeat the name of the client. Wrong: `client.users.get_user()`, Correct: `client.users.get()`
- [x] Typed the returned JSON using TypedDicts in `berserk/types/` — N/A (endpoint returns a URL string, no JSON)
- [x] Written tests for the endpoint (unit tests for URL construction; no VCR — method does not perform a request)
- [x] Added the endpoint to `CHANGELOG.rst` in the `To be released` section
</details>
