### PR TITLE
#6 Add OAuth exchange_code (POST /api/token)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 To be released
 --------------
 
+* Added ``client.oauth.exchange_code`` to exchange an authorization code for an access token (POST /api/token).
 
 * Deprecate Python 3.9 support - minimum required version is now Python 3.10+. This does not mean the library will not work with Python 3.9, but it will not be tested against it anymore.
 

--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,7 @@ Most of the API is available:
 
     client.messaging.send
 
+    client.oauth.exchange_code
     client.oauth.test_tokens
 
     client.puzzles.get_daily

--- a/berserk/clients/oauth.py
+++ b/berserk/clients/oauth.py
@@ -1,12 +1,45 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 from .. import models
+from ..types import OAuthTokenResponse
 from .base import BaseClient
 
 
 class OAuth(BaseClient):
+    def exchange_code(
+        self,
+        code: str,
+        code_verifier: str,
+        client_id: str,
+        redirect_uri: str,
+    ) -> OAuthTokenResponse:
+        """Exchange an authorization code for an access token (POST /api/token).
+
+        Call this after the user returns from the authorization URL with a ``code``
+        in the redirect query string. Use the same ``code_verifier`` that was used
+        to generate the ``code_challenge`` when building the authorization URL.
+
+        :param code: The authorization code from the redirect_uri query string.
+        :param code_verifier: The secret used to derive the code_challenge.
+        :param client_id: Must match the client_id used to request the code.
+        :param redirect_uri: Must match the redirect_uri used to request the code.
+        :return: Token response with access_token, token_type, and expires_in.
+        """
+        path = "/api/token"
+        payload = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": code_verifier,
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+        }
+        return cast(
+            OAuthTokenResponse,
+            self._r.post(path, data=payload),
+        )
+
     def test_tokens(self, *tokens: str) -> Dict[str, Any]:
         """Test the validity of up to 1000 OAuth tokens.
 

--- a/berserk/types/__init__.py
+++ b/berserk/types/__init__.py
@@ -29,6 +29,7 @@ from .opening_explorer import (
 )
 from .studies import ChapterIdName
 from .team import PaginatedTeams, Team
+from .oauth import OAuthTokenResponse
 from .tournaments import ArenaResult, CurrentTournaments, SwissResult, SwissInfo
 from .tv import TVFeed
 
@@ -48,6 +49,7 @@ __all__ = [
     "FidePlayer",
     "LightUser",
     "OnlineLightUser",
+    "OAuthTokenResponse",
     "OpeningExplorerRating",
     "OpeningStatistic",
     "PaginatedBroadcasts",

--- a/berserk/types/oauth.py
+++ b/berserk/types/oauth.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing_extensions import TypedDict
+
+
+class OAuthTokenResponse(TypedDict):
+    """Response from POST /api/token (OAuth2 token exchange)."""
+
+    token_type: str
+    access_token: str
+    expires_in: int

--- a/tests/clients/test_oauth.py
+++ b/tests/clients/test_oauth.py
@@ -1,0 +1,58 @@
+from urllib.parse import parse_qs
+
+import pytest
+import requests_mock
+
+from berserk import Client
+from berserk.types import OAuthTokenResponse
+
+from utils import validate, skip_if_older_3_dot_10
+
+
+class TestOAuthExchangeCode:
+    @skip_if_older_3_dot_10
+    def test_exchange_code_response(self):
+        """Verify that the response matches OAuthTokenResponse."""
+        token_response = {
+            "token_type": "Bearer",
+            "access_token": "lio_abc123",
+            "expires_in": 31536000,
+        }
+        with requests_mock.Mocker() as m:
+            m.post(
+                "https://lichess.org/api/token",
+                json=token_response,
+            )
+            res = Client().oauth.exchange_code(
+                code="auth_code_xyz",
+                code_verifier="verifier_secret",
+                client_id="my-app",
+                redirect_uri="https://example.com/callback",
+            )
+        validate(OAuthTokenResponse, res)
+        assert res["access_token"] == "lio_abc123"
+        assert res["token_type"] == "Bearer"
+        assert res["expires_in"] == 31536000
+
+    def test_exchange_code_sends_form_data(self):
+        """Verify the client sends grant_type, code, code_verifier, client_id, redirect_uri."""
+        with requests_mock.Mocker() as m:
+            m.post(
+                "https://lichess.org/api/token",
+                json={"token_type": "Bearer", "access_token": "x", "expires_in": 0},
+            )
+            Client().oauth.exchange_code(
+                code="c",
+                code_verifier="v",
+                client_id="client",
+                redirect_uri="https://e.com/cb",
+            )
+            assert m.call_count == 1
+            req = m.last_request
+            assert req.method == "POST"
+            form = parse_qs(req.body)
+            assert form["grant_type"] == ["authorization_code"]
+            assert form["code"] == ["c"]
+            assert form["code_verifier"] == ["v"]
+            assert form["client_id"] == ["client"]
+            assert form["redirect_uri"] == ["https://e.com/cb"]


### PR DESCRIPTION
Part of #6.

Adds `client.oauth.exchange_code()` to exchange an authorization code for an access token (POST /api/token). Completes the OAuth2 Authorization Code + PKCE flow: call after the user returns from the authorization URL with a `code`. Response typed as `OAuthTokenResponse` (token_type, access_token, expires_in). Requests-mock tests verify response shape and form body params.

<details>
<summary>Checklist when adding a new endpoint</summary>

- [x] Added new endpoint to the `README.rst`
- [x] Ensured that my endpoint name does not repeat the name of the client. Wrong: `client.users.get_user()`, Correct: `client.users.get()`
- [x] Typed the returned JSON using TypedDicts in `berserk/types/` — `OAuthTokenResponse` in `berserk/types/oauth.py`
- [x] Written tests (requests-mock for POST form body and response validation; no VCR — endpoint requires valid code)
- [x] Added the endpoint to `CHANGELOG.rst` in the `To be released` section
</details>
